### PR TITLE
Add animated bouncing tile on landing page

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -5,11 +5,15 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+  overflow: hidden;
 }
 
 .container {
   text-align: center;
   padding: 2rem;
+  position: relative;
+  z-index: 1;
 }
 
 .title {
@@ -51,4 +55,20 @@ body {
 
 .btn:hover {
   opacity: 0.9;
+}
+
+#flying-tile {
+  position: fixed;
+  width: 60px;
+  height: 60px;
+  background: #fdfdfd;
+  border-radius: 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  color: #000;
+  z-index: 0;
+  pointer-events: none;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/landing.css">
 </head>
 <body>
+  <div id="flying-tile" aria-hidden="true"></div>
   <div class="container">
     <h1 class="title">Mes Premiers Mots</h1>
     <p class="tagline">Bienvenue !</p>

--- a/js/landing.js
+++ b/js/landing.js
@@ -2,6 +2,42 @@
 window.addEventListener('DOMContentLoaded', () => {
   const play = document.getElementById('play');
   const options = document.getElementById('options');
+  const tile = document.getElementById('flying-tile');
+
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const size = 60; // match CSS
+  let x = Math.random() * (window.innerWidth - size);
+  let y = Math.random() * (window.innerHeight - size);
+  let vx = (Math.random() * 0.4 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
+  let vy = (Math.random() * 0.4 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
+
+  const randomLetter = () => letters[Math.floor(Math.random() * letters.length)];
+  tile.textContent = randomLetter();
+
+  const step = () => {
+    x += vx;
+    y += vy;
+
+    const maxX = window.innerWidth - size;
+    const maxY = window.innerHeight - size;
+
+    if (x <= 0 || x >= maxX) {
+      vx *= -1;
+      x = Math.max(0, Math.min(x, maxX));
+      tile.textContent = randomLetter();
+    }
+    if (y <= 0 || y >= maxY) {
+      vy *= -1;
+      y = Math.max(0, Math.min(y, maxY));
+      tile.textContent = randomLetter();
+    }
+
+    tile.style.transform = `translate(${x}px, ${y}px)`;
+    requestAnimationFrame(step);
+  };
+
+  requestAnimationFrame(step);
+
   play.addEventListener('click', () => {
     window.location.href = 'game/';
   });


### PR DESCRIPTION
## Summary
- add tile element in landing page HTML
- style flying tile with fixed positioning and low z-index
- animate the tile bouncing around the screen and changing letter on each bounce

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d68ed337083328bb1ade0db9b8b71