### PR TITLE
Improve landing page tile animation

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -57,7 +57,7 @@ body {
   opacity: 0.9;
 }
 
-#flying-tile {
+.flying-tile {
   position: fixed;
   top: 0;
   left: 0;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,13 @@
   <link rel="stylesheet" href="css/landing.css">
 </head>
 <body>
-  <div id="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
+  <div class="flying-tile" aria-hidden="true"></div>
   <div class="container">
     <h1 class="title">Mes Premiers Mots</h1>
     <p class="tagline">Bienvenue !</p>

--- a/js/landing.js
+++ b/js/landing.js
@@ -2,38 +2,105 @@
 window.addEventListener('DOMContentLoaded', () => {
   const play = document.getElementById('play');
   const options = document.getElementById('options');
-  const tile = document.getElementById('flying-tile');
+  const tiles = Array.from(document.querySelectorAll('.flying-tile'));
 
   const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   const size = 60; // match CSS
-  let x = Math.random() * (window.innerWidth - size);
-  let y = Math.random() * (window.innerHeight - size);
-  let vx = (Math.random() * 0.4 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
-  let vy = (Math.random() * 0.4 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
 
   const randomLetter = () => letters[Math.floor(Math.random() * letters.length)];
-  tile.textContent = randomLetter();
-  tile.style.transform = `translate(${x}px, ${y}px)`;
+  const randomVelocity = () => (Math.random() * 0.4 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
+
+  const states = [];
+
+  const nonOverlappingPosition = () => {
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const x = Math.random() * (window.innerWidth - size);
+      const y = Math.random() * (window.innerHeight - size);
+      let overlap = false;
+      for (const s of states) {
+        if (Math.abs(s.x - x) < size && Math.abs(s.y - y) < size) {
+          overlap = true;
+          break;
+        }
+      }
+      if (!overlap) return { x, y };
+    }
+    return { x: Math.random() * (window.innerWidth - size), y: Math.random() * (window.innerHeight - size) };
+  };
+
+  tiles.forEach((tile) => {
+    const pos = nonOverlappingPosition();
+    tile.textContent = randomLetter();
+    tile.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
+    states.push({
+      x: pos.x,
+      y: pos.y,
+      vx: randomVelocity(),
+      vy: randomVelocity(),
+    });
+  });
 
   const step = () => {
-    x += vx;
-    y += vy;
-
     const maxX = window.innerWidth - size;
     const maxY = window.innerHeight - size;
 
-    if (x <= 0 || x >= maxX) {
-      vx *= -1;
-      x = Math.max(0, Math.min(x, maxX));
-      tile.textContent = randomLetter();
-    }
-    if (y <= 0 || y >= maxY) {
-      vy *= -1;
-      y = Math.max(0, Math.min(y, maxY));
-      tile.textContent = randomLetter();
+    // move and bounce on edges
+    for (const s of states) {
+      s.x += s.vx;
+      s.y += s.vy;
+
+      if (s.x <= 0 || s.x >= maxX) {
+        s.vx *= -1;
+        s.x = Math.max(0, Math.min(s.x, maxX));
+      }
+      if (s.y <= 0 || s.y >= maxY) {
+        s.vy *= -1;
+        s.y = Math.max(0, Math.min(s.y, maxY));
+      }
     }
 
-    tile.style.transform = `translate(${x}px, ${y}px)`;
+    // collisions between tiles
+    for (let i = 0; i < states.length; i++) {
+      for (let j = i + 1; j < states.length; j++) {
+        const a = states[i];
+        const b = states[j];
+        if (Math.abs(a.x - b.x) < size && Math.abs(a.y - b.y) < size) {
+          const tmpVx = a.vx;
+          const tmpVy = a.vy;
+          a.vx = b.vx;
+          a.vy = b.vy;
+          b.vx = tmpVx;
+          b.vy = tmpVy;
+
+          const overlapX = size - Math.abs(a.x - b.x);
+          const overlapY = size - Math.abs(a.y - b.y);
+          if (overlapX > 0) {
+            if (a.x < b.x) {
+              a.x -= overlapX / 2;
+              b.x += overlapX / 2;
+            } else {
+              a.x += overlapX / 2;
+              b.x -= overlapX / 2;
+            }
+          }
+          if (overlapY > 0) {
+            if (a.y < b.y) {
+              a.y -= overlapY / 2;
+              b.y += overlapY / 2;
+            } else {
+              a.y += overlapY / 2;
+              b.y -= overlapY / 2;
+            }
+          }
+        }
+      }
+    }
+
+    tiles.forEach((tile, i) => {
+      const s = states[i];
+      tile.style.transform = `translate(${s.x}px, ${s.y}px)`;
+    });
+
     requestAnimationFrame(step);
   };
 


### PR DESCRIPTION
## Summary
- support multiple bouncing tiles
- style `.flying-tile` element
- add seven tiles to the landing page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e040fbc048332a95e9bd79d09aec8