### PR TITLE
Add basic playable game

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -1,1 +1,51 @@
 /* Game screen styling */
+body {
+  text-align: center;
+  padding-top: 2rem;
+}
+#picture {
+  font-size: 5rem;
+  margin-bottom: 1rem;
+}
+.word {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+.slot {
+  width: 40px;
+  height: 50px;
+  border: 2px dashed #555;
+  border-radius: 6px;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.slot.filled {
+  border-style: solid;
+}
+.tiles {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.tile {
+  width: 40px;
+  height: 50px;
+  background: #fdfdfd;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  cursor: grab;
+}
+.next {
+  margin-top: 2rem;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+}

--- a/game/data/words-fr.json
+++ b/game/data/words-fr.json
@@ -1,1 +1,5 @@
-[]
+[
+  {"word": "CHAT", "emoji": "🐱"},
+  {"word": "CHIEN", "emoji": "🐶"},
+  {"word": "POIRE", "emoji": "🍐"}
+]

--- a/game/index.html
+++ b/game/index.html
@@ -1,1 +1,17 @@
-<!DOCTYPE html><html><head><title>Jeu - Mes Premiers Mots</title></head><body><h1>Jeu</h1></body></html>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jeu - Mes Premiers Mots</title>
+  <link rel="stylesheet" href="../css/base.css">
+  <link rel="stylesheet" href="css/game.css">
+</head>
+<body>
+  <div id="picture" aria-label="Illustration"></div>
+  <div id="word" class="word"></div>
+  <div id="tiles" class="tiles"></div>
+  <button id="next" class="next" style="display:none;">Nouveau mot</button>
+  <script type="module" src="js/main.mjs"></script>
+</body>
+</html>

--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -1,1 +1,16 @@
-// Audio handling
+export function playSuccess() {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const o = ctx.createOscillator();
+    const g = ctx.createGain();
+    o.type = 'sine';
+    o.frequency.value = 880;
+    o.connect(g);
+    g.connect(ctx.destination);
+    o.start();
+    g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.5);
+    o.stop(ctx.currentTime + 0.5);
+  } catch (e) {
+    console.log('Success!');
+  }
+}

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -1,1 +1,29 @@
-// Drag and drop logic
+export function setupDragDrop(slots, tiles, onComplete) {
+  tiles.forEach((tile) => {
+    tile.draggable = true;
+    tile.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', tile.textContent);
+    });
+  });
+
+  slots.forEach((slot) => {
+    slot.addEventListener('dragover', (e) => e.preventDefault());
+    slot.addEventListener('drop', (e) => {
+      e.preventDefault();
+      if (slot.textContent) return;
+      const letter = e.dataTransfer.getData('text/plain');
+      if (letter === slot.dataset.letter) {
+        slot.textContent = letter;
+        slot.classList.add('filled');
+        const tile = tiles.find((t) => t.textContent === letter && !t.used);
+        if (tile) {
+          tile.used = true;
+          tile.style.visibility = 'hidden';
+        }
+        if (slots.every((s) => s.classList.contains('filled'))) {
+          onComplete();
+        }
+      }
+    });
+  });
+}

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -1,1 +1,73 @@
-// Main game setup
+import { setupDragDrop } from './drag-drop.mjs';
+import { allSlotsFilled } from './word-check.mjs';
+import { playSuccess } from './audio.mjs';
+
+async function loadWords() {
+  const res = await fetch('../data/words-fr.json');
+  return res.json();
+}
+
+function pickWord(words) {
+  return words[Math.floor(Math.random() * words.length)];
+}
+
+function createSlots(word) {
+  const container = document.getElementById('word');
+  container.innerHTML = '';
+  const slots = [];
+  for (const letter of word) {
+    const d = document.createElement('div');
+    d.className = 'slot';
+    d.dataset.letter = letter;
+    container.appendChild(d);
+    slots.push(d);
+  }
+  return slots;
+}
+
+function createTiles(word) {
+  const container = document.getElementById('tiles');
+  container.innerHTML = '';
+  const letters = word.split('');
+  // simple shuffle
+  for (let i = letters.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [letters[i], letters[j]] = [letters[j], letters[i]];
+  }
+  const tiles = [];
+  for (const letter of letters) {
+    const d = document.createElement('div');
+    d.className = 'tile';
+    d.textContent = letter;
+    container.appendChild(d);
+    tiles.push(d);
+  }
+  return tiles;
+}
+
+function showWord(wordObj) {
+  document.getElementById('picture').textContent = wordObj.emoji;
+  const slots = createSlots(wordObj.word);
+  const tiles = createTiles(wordObj.word);
+  const nextBtn = document.getElementById('next');
+  nextBtn.style.display = 'none';
+  setupDragDrop(slots, tiles, () => {
+    if (allSlotsFilled(slots)) {
+      playSuccess();
+      nextBtn.style.display = 'inline-block';
+    }
+  });
+  nextBtn.onclick = () => startGame();
+}
+
+let wordList = [];
+
+async function startGame() {
+  if (wordList.length === 0) {
+    wordList = await loadWords();
+  }
+  const word = pickWord(wordList);
+  showWord(word);
+}
+
+window.addEventListener('DOMContentLoaded', startGame);

--- a/game/js/word-check.mjs
+++ b/game/js/word-check.mjs
@@ -1,1 +1,3 @@
-// Word checking logic
+export function allSlotsFilled(slots) {
+  return slots.every((s) => s.classList.contains('filled'));
+}


### PR DESCRIPTION
## Summary
- implement simple drag-and-drop word puzzle
- add emoji-based word list
- style game screen with CSS
- load game logic via ES modules

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -s http://localhost:8000/game/ | head`
- `kill %1`

------
https://chatgpt.com/codex/tasks/task_e_687e085bba908332b9c44dfb206d41f1