### PR TITLE
Refine version label styling

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -78,9 +78,11 @@ body {
 /* discreet version label */
 .version {
   position: fixed;
-  bottom: 4px;
+  top: 4px;
   right: 6px;
-  font-size: 0.6rem;
-  color: rgba(0, 0, 0, 0.5);
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: "Courier New", Courier, monospace;
   z-index: 1;
+  pointer-events: none;
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <button id="options" class="btn options">Options</button>
     </div>
   </div>
-  <div class="version">v9 – 2025-07-21 09:46 UTC</div>
+  <div class="version">v9 – 2025-07-21 11:46 CEST</div>
   <script src="js/landing.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve version label styling and positioning
- update example timestamp to Central European time

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687e13994d248332a80bdc4cd2e34306