### PR TITLE
Improve tile interactivity and hints

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -22,6 +22,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  color: #000;
+}
+.slot.preview {
+  opacity: 0.3;
 }
 .slot.filled {
   border-style: solid;
@@ -31,6 +35,7 @@ body {
   justify-content: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+  position: relative;
 }
 .tile {
   width: 40px;

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -1,29 +1,57 @@
 export function setupDragDrop(slots, tiles, onComplete) {
-  tiles.forEach((tile) => {
-    tile.draggable = true;
-    tile.addEventListener('dragstart', (e) => {
-      e.dataTransfer.setData('text/plain', tile.textContent);
-    });
-  });
+  const isComplete = () => slots.every((s) => s.classList.contains('filled'));
 
-  slots.forEach((slot) => {
-    slot.addEventListener('dragover', (e) => e.preventDefault());
-    slot.addEventListener('drop', (e) => {
-      e.preventDefault();
-      if (slot.textContent) return;
-      const letter = e.dataTransfer.getData('text/plain');
-      if (letter === slot.dataset.letter) {
-        slot.textContent = letter;
-        slot.classList.add('filled');
-        const tile = tiles.find((t) => t.textContent === letter && !t.used);
-        if (tile) {
+  tiles.forEach((tile) => {
+    tile.draggable = false;
+    tile.style.touchAction = 'none';
+    let startX, startY;
+
+    const move = (e) => {
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      tile.style.transform = `translate(${dx}px, ${dy}px)`;
+    };
+
+    const end = (e) => {
+      tile.removeEventListener('pointermove', move);
+      tile.removeEventListener('pointerup', end);
+      tile.removeEventListener('pointercancel', end);
+      tile.releasePointerCapture(e.pointerId);
+      tile.style.transform = '';
+
+      const dropSlot = slots.find((slot) => {
+        const r = slot.getBoundingClientRect();
+        return (
+          e.clientX >= r.left &&
+          e.clientX <= r.right &&
+          e.clientY >= r.top &&
+          e.clientY <= r.bottom
+        );
+      });
+
+      if (dropSlot && !dropSlot.textContent) {
+        const letter = tile.textContent;
+        if (letter === dropSlot.dataset.letter) {
+          dropSlot.textContent = letter;
+          dropSlot.classList.add('filled');
+          dropSlot.classList.remove('preview');
           tile.used = true;
           tile.style.visibility = 'hidden';
-        }
-        if (slots.every((s) => s.classList.contains('filled'))) {
-          onComplete();
+          if (isComplete()) {
+            onComplete();
+          }
         }
       }
+    };
+
+    tile.addEventListener('pointerdown', (e) => {
+      if (tile.used) return;
+      startX = e.clientX;
+      startY = e.clientY;
+      tile.setPointerCapture(e.pointerId);
+      tile.addEventListener('pointermove', move);
+      tile.addEventListener('pointerup', end);
+      tile.addEventListener('pointercancel', end);
     });
   });
 }

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -22,8 +22,9 @@ function createSlots(word) {
   const slots = [];
   for (const letter of word) {
     const d = document.createElement('div');
-    d.className = 'slot';
+    d.className = 'slot preview';
     d.dataset.letter = letter;
+    d.textContent = letter;
     container.appendChild(d);
     slots.push(d);
   }
@@ -34,6 +35,10 @@ function createTiles(word) {
   const container = document.getElementById('tiles');
   container.innerHTML = '';
   const letters = word.split('');
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  while (letters.length < word.length + 3) {
+    letters.push(alphabet[Math.floor(Math.random() * alphabet.length)]);
+  }
   // simple shuffle
   for (let i = letters.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));


### PR DESCRIPTION
## Summary
- show faint letter previews in each slot
- add distractor letters
- rewrite drag & drop logic to use pointer events for instant pickup

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e39d983048332abac30fb0558fe49