### PR TITLE
Improve drag-drop mechanics

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -31,11 +31,9 @@ body {
   border-style: solid;
 }
 .tiles {
-  display: flex;
-  justify-content: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
   position: relative;
+  height: 35vh;
+  max-height: 300px;
 }
 .tile {
   width: 40px;
@@ -48,6 +46,10 @@ body {
   justify-content: center;
   font-size: 2rem;
   cursor: grab;
+  position: absolute;
+}
+.slot.hover {
+  box-shadow: 0 0 0 4px rgba(255, 165, 0, 0.6);
 }
 .next {
   margin-top: 2rem;

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -1,5 +1,19 @@
 export function setupDragDrop(slots, tiles, onComplete) {
   const isComplete = () => slots.every((s) => s.classList.contains('filled'));
+  let current;
+
+  const intersectingSlot = (tile) => {
+    const t = tile.getBoundingClientRect();
+    return slots.find((slot) => {
+      const r = slot.getBoundingClientRect();
+      return (
+        t.right > r.left &&
+        t.left < r.right &&
+        t.bottom > r.top &&
+        t.top < r.bottom
+      );
+    });
+  };
 
   tiles.forEach((tile) => {
     tile.draggable = false;
@@ -10,6 +24,20 @@ export function setupDragDrop(slots, tiles, onComplete) {
       const dx = e.clientX - startX;
       const dy = e.clientY - startY;
       tile.style.transform = `translate(${dx}px, ${dy}px)`;
+
+      const over = intersectingSlot(tile);
+      if (over !== current) {
+        if (current) current.classList.remove('hover');
+        if (over && !over.textContent) over.classList.add('hover');
+        current = over;
+      }
+    };
+
+    const clearHover = () => {
+      if (current) {
+        current.classList.remove('hover');
+        current = null;
+      }
     };
 
     const end = (e) => {
@@ -17,17 +45,9 @@ export function setupDragDrop(slots, tiles, onComplete) {
       tile.removeEventListener('pointerup', end);
       tile.removeEventListener('pointercancel', end);
       tile.releasePointerCapture(e.pointerId);
+      const dropSlot = intersectingSlot(tile);
       tile.style.transform = '';
-
-      const dropSlot = slots.find((slot) => {
-        const r = slot.getBoundingClientRect();
-        return (
-          e.clientX >= r.left &&
-          e.clientX <= r.right &&
-          e.clientY >= r.top &&
-          e.clientY <= r.bottom
-        );
-      });
+      clearHover();
 
       if (dropSlot && !dropSlot.textContent) {
         const letter = tile.textContent;

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -45,10 +45,15 @@ function createTiles(word) {
     [letters[i], letters[j]] = [letters[j], letters[i]];
   }
   const tiles = [];
+  const { width, height } = container.getBoundingClientRect();
   for (const letter of letters) {
     const d = document.createElement('div');
     d.className = 'tile';
     d.textContent = letter;
+    const x = Math.random() * (width - 40);
+    const y = Math.random() * (height - 50);
+    d.style.left = `${x}px`;
+    d.style.top = `${y}px`;
     container.appendChild(d);
     tiles.push(d);
   }


### PR DESCRIPTION
## Summary
- enlarge drop target detection and highlight hover slot
- randomize letter tile placement in tile area
- add hover cue and scatter layout styles

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_687e3c7b96c88332a5cf8da04032abe5