### PR TITLE
Fix hover detection and timestamp

### DIFF
--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -28,7 +28,7 @@ export function setupDragDrop(slots, tiles, onComplete) {
       const over = intersectingSlot(tile);
       if (over !== current) {
         if (current) current.classList.remove('hover');
-        if (over && !over.textContent) over.classList.add('hover');
+        if (over && !over.classList.contains('filled')) over.classList.add('hover');
         current = over;
       }
     };
@@ -49,7 +49,7 @@ export function setupDragDrop(slots, tiles, onComplete) {
       tile.style.transform = '';
       clearHover();
 
-      if (dropSlot && !dropSlot.textContent) {
+      if (dropSlot && !dropSlot.classList.contains('filled')) {
         const letter = tile.textContent;
         if (letter === dropSlot.dataset.letter) {
           dropSlot.textContent = letter;

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <button id="options" class="btn options">Options</button>
     </div>
   </div>
-  <div class="version">v9 – 2025-07-21 11:46 CEST</div>
+  <div class="version">2025-07-21 18:48 CEST</div>
   <script src="js/landing.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix tile overlap check to use `filled` CSS class
- update the landing page version timestamp

## Testing
- `node netlify/functions/generate.js` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e739ee804833299a0df2f8ddfe9c5