### PR TITLE
Improve tile placement feedback

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -49,10 +49,58 @@ body {
   position: absolute;
 }
 .slot.hover {
-  box-shadow: 0 0 0 4px rgba(255, 165, 0, 0.6);
+  box-shadow: 0 0 0 6px rgba(255, 165, 0, 0.9);
 }
 .next {
   margin-top: 2rem;
+}
+
+.btn {
   font-size: 1rem;
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  opacity: 0.9;
+}
+
+.play {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+.slot.placed {
+  animation: pop 0.3s ease;
+}
+
+@keyframes pop {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
+#message {
+  font-size: 2.5rem;
+  color: #4caf50;
+  margin-top: 1rem;
+  display: none;
+}
+
+.confetti-container {
+  position: relative;
+  height: 0;
+}
+
+.confetti {
+  position: absolute;
+  animation: fall 1s ease-out forwards;
+  font-size: 1.5rem;
+}
+
+@keyframes fall {
+  0% { transform: translateY(0); opacity: 1; }
+  100% { transform: translateY(100px); opacity: 0; }
 }

--- a/game/index.html
+++ b/game/index.html
@@ -11,7 +11,9 @@
   <div id="picture" aria-label="Illustration"></div>
   <div id="word" class="word"></div>
   <div id="tiles" class="tiles"></div>
-  <button id="next" class="next" style="display:none;">Nouveau mot</button>
+  <div id="confetti" class="confetti-container"></div>
+  <div id="message" class="message"></div>
+  <button id="next" class="next btn play" style="display:none;">Nouveau mot</button>
   <script type="module" src="js/main.mjs"></script>
 </body>
 </html>

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -1,3 +1,5 @@
+import { playSuccess } from './audio.mjs';
+
 export function setupDragDrop(slots, tiles, onComplete) {
   const isComplete = () => slots.every((s) => s.classList.contains('filled'));
   let current;
@@ -49,19 +51,21 @@ export function setupDragDrop(slots, tiles, onComplete) {
       tile.style.transform = '';
       clearHover();
 
-      if (dropSlot && !dropSlot.classList.contains('filled')) {
-        const letter = tile.textContent;
-        if (letter === dropSlot.dataset.letter) {
-          dropSlot.textContent = letter;
-          dropSlot.classList.add('filled');
-          dropSlot.classList.remove('preview');
-          tile.used = true;
-          tile.style.visibility = 'hidden';
-          if (isComplete()) {
-            onComplete();
+        if (dropSlot && !dropSlot.classList.contains('filled')) {
+          const letter = tile.textContent;
+          if (letter === dropSlot.dataset.letter) {
+            dropSlot.textContent = letter;
+            dropSlot.classList.add('filled', 'placed');
+            dropSlot.classList.remove('preview');
+            tile.used = true;
+            tile.style.visibility = 'hidden';
+            playSuccess();
+            dropSlot.addEventListener('animationend', () => dropSlot.classList.remove('placed'), { once: true });
+            if (isComplete()) {
+              onComplete();
+            }
           }
         }
-      }
     };
 
     tile.addEventListener('pointerdown', (e) => {

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -45,19 +45,59 @@ function createTiles(word) {
     [letters[i], letters[j]] = [letters[j], letters[i]];
   }
   const tiles = [];
+  const positions = [];
   const { width, height } = container.getBoundingClientRect();
+  const tileW = 40;
+  const tileH = 50;
+  const spacing = 10;
+
+  const nonOverlappingPos = () => {
+    for (let tries = 0; tries < 50; tries++) {
+      const x = Math.random() * (width - tileW);
+      const y = Math.random() * (height - tileH);
+      let overlap = false;
+      for (const p of positions) {
+        if (Math.abs(p.x - x) < tileW + spacing && Math.abs(p.y - y) < tileH + spacing) {
+          overlap = true;
+          break;
+        }
+      }
+      if (!overlap) return { x, y };
+    }
+    return { x: Math.random() * (width - tileW), y: Math.random() * (height - tileH) };
+  };
+
   for (const letter of letters) {
     const d = document.createElement('div');
     d.className = 'tile';
     d.textContent = letter;
-    const x = Math.random() * (width - 40);
-    const y = Math.random() * (height - 50);
-    d.style.left = `${x}px`;
-    d.style.top = `${y}px`;
+    const pos = nonOverlappingPos();
+    positions.push(pos);
+    d.style.left = `${pos.x}px`;
+    d.style.top = `${pos.y}px`;
     container.appendChild(d);
     tiles.push(d);
   }
   return tiles;
+}
+
+function celebrate() {
+  const msg = document.getElementById('message');
+  const confetti = document.getElementById('confetti');
+  msg.textContent = 'Bravo !';
+  msg.style.display = 'block';
+  confetti.innerHTML = '';
+  for (let i = 0; i < 20; i++) {
+    const span = document.createElement('span');
+    span.className = 'confetti';
+    span.textContent = '🎉';
+    span.style.left = Math.random() * 100 + '%';
+    confetti.appendChild(span);
+  }
+  setTimeout(() => {
+    msg.style.display = 'none';
+    confetti.innerHTML = '';
+  }, 1500);
 }
 
 function showWord(wordObj) {
@@ -66,9 +106,12 @@ function showWord(wordObj) {
   const tiles = createTiles(wordObj.word);
   const nextBtn = document.getElementById('next');
   nextBtn.style.display = 'none';
+  document.getElementById('message').style.display = 'none';
+  document.getElementById('confetti').innerHTML = '';
   setupDragDrop(slots, tiles, () => {
     if (allSlotsFilled(slots)) {
       playSuccess();
+      celebrate();
       nextBtn.style.display = 'inline-block';
     }
   });


### PR DESCRIPTION
## Summary
- prevent tiles from overlapping by tracking positions
- highlight slots with a thicker glow on hover
- animate and play a sound when a tile is placed
- style Next Word button like landing page buttons
- celebrate with confetti and a 'Bravo !' message on completion

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_687e7860119c8332a2f7b4e87f629184