### PR TITLE
Update celebration animations

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -111,7 +111,7 @@ body {
 .confetti {
   position: absolute;
   top: -10px;
-  font-size: 1.5rem;
+  font-size: 2.5rem;
   animation: fall var(--duration, 4s) linear forwards;
   left: var(--x, 0);
   transform: translateX(0);
@@ -119,22 +119,22 @@ body {
 
 @keyframes fall {
   0% {
-    transform: translateX(0) translateY(0);
+    transform: translateX(0) translateY(0) rotate(0deg);
     opacity: 1;
   }
   100% {
-    transform: translateX(var(--sway, 0)) translateY(100vh);
+    transform: translateX(var(--sway, 0)) translateY(100vh) rotate(var(--rotate, 360deg));
     opacity: 0;
   }
 }
 
 #picture.animate {
-  animation: bounce 1s ease-in-out infinite alternate;
+  animation: bounce 0.6s ease-in-out infinite alternate;
 }
 
 @keyframes bounce {
-  from { transform: scale(1); }
-  to { transform: scale(1.2); }
+  from { transform: scale(0.9); }
+  to { transform: scale(1.3); }
 }
 
 @keyframes popIn {

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -90,10 +90,11 @@ function startConfetti() {
   confettiInterval = setInterval(() => {
     const span = document.createElement('span');
     span.className = 'confetti';
-    span.textContent = '🎉';
+    span.textContent = Math.random() < 0.5 ? '🔶' : '🔷';
     span.style.setProperty('--x', Math.random() * 100 + '%');
     span.style.setProperty('--sway', (Math.random() * 60 - 30) + 'px');
     span.style.setProperty('--duration', 4 + Math.random() * 2 + 's');
+    span.style.setProperty('--rotate', (Math.random() < 0.5 ? '-' : '') + '720deg');
     container.appendChild(span);
     span.addEventListener('animationend', () => span.remove());
   }, 300);
@@ -113,11 +114,11 @@ function startPictureAnimation() {
   pic.classList.add('animate');
   bounceHandler = () => {
     bounceCount++;
-    if (bounceCount % 5 === 0) {
+    if (bounceCount % 10 === 0) {
       pic.animate([
-        { transform: 'scale(1.2) rotate(0deg)' },
-        { transform: 'scale(1.2) rotate(360deg)' }
-      ], { duration: 600 });
+        { transform: 'scale(1.3) rotate(0deg)' },
+        { transform: 'scale(1.3) rotate(360deg)' }
+      ], { duration: 400 });
     }
   };
   pic.addEventListener('animationiteration', bounceHandler);


### PR DESCRIPTION
## Summary
- animate falling diamonds instead of confetti
- spin diamonds while they fall
- speed up picture bounce and amplify scaling
- spin picture every 10 cycles

## Testing
- `node --check game/js/main.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687e864499408332ba77c7a759384862