### PR TITLE
Improve victory overlay

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -54,6 +54,13 @@ body {
 }
 .next {
   margin-top: 2rem;
+  position: fixed;
+  left: 50%;
+  top: 60%;
+  transform: translateX(-50%);
+  z-index: 2;
+  font-size: 1.5rem;
+  padding: 1rem 2rem;
 }
 
 .btn {
@@ -90,6 +97,11 @@ body {
   margin-top: 1rem;
   display: none;
   pointer-events: none;
+  position: fixed;
+  left: 50%;
+  top: 45%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
 }
 
 #message.show {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <button id="options" class="btn options">Options</button>
     </div>
   </div>
-  <div class="version">2025-07-21 18:48 CEST</div>
+  <div class="version">2025-07-21 20:39 CEST</div>
   <script src="js/landing.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- center the victory message and next button
- ensure they layer above tiles
- enlarge the next button
- update timestamp

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687e892706f48332af8677df99674194