### PR TITLE
Remove glow and responsively size success message

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -93,7 +93,7 @@ body {
 }
 
 #message {
-  font-size: 3.5rem;
+  font-size: clamp(2rem, 10vw, 5rem);
   font-weight: 900;
   margin-top: 1rem;
   display: none;
@@ -102,7 +102,7 @@ body {
   left: 50%;
   top: 45%;
   transform: translate(-50%, -50%);
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.8), 0 0 20px #ff4081;
+  white-space: nowrap;
   z-index: 2;
 }
 


### PR DESCRIPTION
## Summary
- tone down the win message by removing the glow
- make the "Bravo!" message scale with the viewport so it stays on one line

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687eab3287748332b5fc47a3c0d19c8c