### PR TITLE
Update tile animation and next button

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -61,8 +61,8 @@ body {
   top: 60%;
   transform: translateX(-50%);
   z-index: 2;
-  font-size: 1.5rem;
-  padding: 1rem 2rem;
+  font-size: 2rem;
+  padding: 1.25rem 2.5rem;
 }
 
 .btn {
@@ -158,7 +158,7 @@ body {
 }
 
 .tile.drop {
-  animation: tile-fall var(--duration, 1.2s) cubic-bezier(0.2, 0.8, 0.4, 1) forwards;
+  animation: tile-fall var(--duration, 1.6s) cubic-bezier(0.2, 0.8, 0.4, 1) var(--delay, 0s) forwards;
 }
 
 @keyframes tile-fall {

--- a/game/index.html
+++ b/game/index.html
@@ -13,7 +13,7 @@
   <div id="tiles" class="tiles"></div>
   <div id="confetti" class="confetti-container"></div>
   <div id="message" class="message"></div>
-  <button id="next" class="next btn play" style="display:none;">Mot suivant</button>
+  <button id="next" class="next btn play" style="display:none;">Mot suivant <span aria-hidden="true">➡️</span></button>
   <script type="module" src="js/main.mjs"></script>
 </body>
 </html>

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -201,7 +201,8 @@ function dropUnusedTiles() {
     if (tile.used) return;
     tile.classList.add('drop');
     tile.style.setProperty('--spin', `${Math.random() * 60 - 30}deg`);
-    tile.style.setProperty('--duration', `${1 + Math.random()}s`);
+    tile.style.setProperty('--duration', `${1.5 + Math.random()}s`);
+    tile.style.setProperty('--delay', `${Math.random() * 0.5}s`);
     tile.addEventListener('animationend', () => tile.remove(), { once: true });
   });
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       <button id="options" class="btn options">Options</button>
     </div>
   </div>
-  <div class="version">2025-07-21 20:39 CEST</div>
+  <div class="version">2025-07-22 10:45 CEST</div>
   <script src="js/landing.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- slow down victory tile fall and add per-tile random delay
- enlarge "Mot suivant" button and add arrow emoji
- refresh landing page timestamp

## Testing
- `node --check game/js/main.mjs`
- `node --check js/landing.js`

------
https://chatgpt.com/codex/tasks/task_e_687f4f40f78c8332a8e7404d67d1bf92