### PR TITLE
Add session word history

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Visual targets	Faint, outlined letters act as soft guidance without making the a
 Positive reinforcement	Correct placement triggers gentle animations and sounds (e.g., a “pop” or happy chime).
 Negative feedback	Wrong placement gives immediate but soft feedback (e.g., shake effect, gentle “nope” sound).
 Completion celebration	When a word is completed, a short success animation plays, followed by a “Nouveau mot” button to continue playing.
+Word history        Each solved word's emoji appears at the bottom of the screen and stays for the session until returning to the start page.
 Simple navigation	Only two main screens: Landing Page and Game. Options accessible via a gear icon (to skip puzzles, toggle settings).
 No distractions	Minimal text, no advertisements, no popups—pure focus on the learning experience.
 

--- a/game/css/game.css
+++ b/game/css/game.css
@@ -168,3 +168,20 @@ body {
   }
 }
 
+/* Word history at bottom of screen */
+.history {
+  position: fixed;
+  bottom: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  grid-template-columns: repeat(10, auto);
+  gap: 0.25rem 0.5rem;
+  max-width: 100%;
+  pointer-events: none;
+}
+
+.history-emoji {
+  font-size: 1.5rem;
+}
+

--- a/game/index.html
+++ b/game/index.html
@@ -13,6 +13,7 @@
   <div id="tiles" class="tiles"></div>
   <div id="confetti" class="confetti-container"></div>
   <div id="message" class="message"></div>
+  <div id="history" class="history"></div>
   <button id="next" class="next btn play" style="display:none;">Mot suivant <span aria-hidden="true">➡️</span></button>
   <script type="module" src="js/main.mjs"></script>
 </body>

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -7,6 +7,40 @@ let bounceCount = 0;
 let bounceHandler;
 let currentTiles = [];
 
+// Emoji history management
+let wordHistory = [];
+
+function loadHistory() {
+  const stored = sessionStorage.getItem('wordHistory');
+  wordHistory = stored ? JSON.parse(stored) : [];
+}
+
+function saveHistory() {
+  sessionStorage.setItem('wordHistory', JSON.stringify(wordHistory));
+}
+
+function renderHistory() {
+  const container = document.getElementById('history');
+  if (!container) return;
+  container.innerHTML = '';
+  const recent = wordHistory.slice(-30);
+  recent.forEach((emoji) => {
+    const span = document.createElement('span');
+    span.className = 'history-emoji';
+    span.textContent = emoji;
+    container.appendChild(span);
+  });
+}
+
+function addToHistory(emoji) {
+  wordHistory.push(emoji);
+  if (wordHistory.length > 30) {
+    wordHistory = wordHistory.slice(-30);
+  }
+  saveHistory();
+  renderHistory();
+}
+
 async function loadWords() {
   // When the game is loaded from /game/index.html, the words JSON
   // lives in the sibling "data" directory. The previous relative
@@ -252,6 +286,7 @@ function showWord(wordObj) {
     if (allSlotsFilled(slots)) {
       playSuccess();
       animateWordReveal(slots).then(() => {
+        addToHistory(wordObj.emoji);
         celebrate();
         nextBtn.style.display = 'inline-block';
       });
@@ -268,4 +303,8 @@ async function startGame() {
   showWord(word);
 }
 
-window.addEventListener('DOMContentLoaded', startGame);
+window.addEventListener('DOMContentLoaded', () => {
+  loadHistory();
+  renderHistory();
+  startGame();
+});

--- a/js/landing.js
+++ b/js/landing.js
@@ -1,5 +1,7 @@
 // Landing page interactions
 window.addEventListener('DOMContentLoaded', () => {
+  // Reset word history when returning to the start screen
+  sessionStorage.removeItem('wordHistory');
   const play = document.getElementById('play');
   const options = document.getElementById('options');
   const tiles = Array.from(document.querySelectorAll('.flying-tile'));


### PR DESCRIPTION
## Summary
- track solved word history and render as mini emojis
- clear history when returning to landing page
- style bottom history container
- document the new feature

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f9454ae748332b9206c8c0257c9bd