### PR TITLE
Add settings popup to game

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -185,3 +185,48 @@ body {
   font-size: 1.5rem;
 }
 
+/* Settings button */
+.settings-btn {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  z-index: 3;
+}
+
+/* Modal overlay */
+.settings-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 4;
+}
+
+.settings-modal.hidden {
+  display: none;
+}
+
+.settings-modal .modal-content {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.btn.options {
+  background-color: #2196f3;
+  color: #fff;
+}
+

--- a/game/index.html
+++ b/game/index.html
@@ -14,6 +14,15 @@
   <div id="confetti" class="confetti-container"></div>
   <div id="message" class="message"></div>
   <div id="history" class="history"></div>
+  <button id="settings-btn" class="settings-btn" aria-label="Param\u00e8tres">⚙️</button>
+  <div id="settings-modal" class="settings-modal hidden" role="dialog" aria-modal="true" aria-labelledby="settings-title">
+    <div class="modal-content">
+      <h2 id="settings-title">Param\u00e8tres</h2>
+      <button id="continue-btn" class="btn play">Continuer</button>
+      <button id="skip-btn" class="btn options">Passer ce mot</button>
+      <button id="menu-btn" class="btn options">Retour au menu</button>
+    </div>
+  </div>
   <button id="next" class="next btn play" style="display:none;">Mot suivant <span aria-hidden="true">➡️</span></button>
   <script type="module" src="js/main.mjs"></script>
 </body>

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -303,8 +303,32 @@ async function startGame() {
   showWord(word);
 }
 
+function openSettings() {
+  document.getElementById('settings-modal').classList.remove('hidden');
+}
+
+function closeSettings() {
+  document.getElementById('settings-modal').classList.add('hidden');
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   loadHistory();
   renderHistory();
   startGame();
+
+  const settingsBtn = document.getElementById('settings-btn');
+  const continueBtn = document.getElementById('continue-btn');
+  const skipBtn = document.getElementById('skip-btn');
+  const menuBtn = document.getElementById('menu-btn');
+
+  settingsBtn.addEventListener('click', openSettings);
+  continueBtn.addEventListener('click', closeSettings);
+  skipBtn.addEventListener('click', () => {
+    closeSettings();
+    startGame();
+  });
+  menuBtn.addEventListener('click', () => {
+    sessionStorage.removeItem('wordHistory');
+    window.location.href = '../';
+  });
 });


### PR DESCRIPTION
## Summary
- add settings button with modal actions
- style modal overlay and options
- implement logic to open and close popup, skip word or return to menu

## Testing
- `npm test` *(fails: ENOENT: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68800ad5eb4083329db58833df45e434