### PR TITLE
Improve pause screen UI

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -189,10 +189,10 @@ body {
 .settings-btn {
   position: fixed;
   top: 0.5rem;
-  right: 0.5rem;
+  right: 0.25rem;
   background: none;
   border: none;
-  font-size: 2rem;
+  font-size: 1.6rem;
   cursor: pointer;
   z-index: 3;
 }
@@ -227,6 +227,11 @@ body {
 
 .btn.options {
   background-color: #2196f3;
+  color: #fff;
+}
+
+#menu-btn {
+  background-color: #f44336;
   color: #fff;
 }
 

--- a/game/index.html
+++ b/game/index.html
@@ -14,10 +14,10 @@
   <div id="confetti" class="confetti-container"></div>
   <div id="message" class="message"></div>
   <div id="history" class="history"></div>
-  <button id="settings-btn" class="settings-btn" aria-label="Param\u00e8tres">⚙️</button>
+  <button id="settings-btn" class="settings-btn" aria-label="Paramètres">⚙️</button>
   <div id="settings-modal" class="settings-modal hidden" role="dialog" aria-modal="true" aria-labelledby="settings-title">
     <div class="modal-content">
-      <h2 id="settings-title">Param\u00e8tres</h2>
+      <h2 id="settings-title">Paramètres</h2>
       <button id="continue-btn" class="btn play">Continuer</button>
       <button id="skip-btn" class="btn options">Passer ce mot</button>
       <button id="menu-btn" class="btn options">Retour au menu</button>

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -320,9 +320,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const continueBtn = document.getElementById('continue-btn');
   const skipBtn = document.getElementById('skip-btn');
   const menuBtn = document.getElementById('menu-btn');
+  const settingsModal = document.getElementById('settings-modal');
 
   settingsBtn.addEventListener('click', openSettings);
   continueBtn.addEventListener('click', closeSettings);
+  settingsModal.addEventListener('click', (e) => {
+    if (e.target === settingsModal) {
+      closeSettings();
+    }
+  });
   skipBtn.addEventListener('click', () => {
     closeSettings();
     startGame();


### PR DESCRIPTION
## Summary
- fix accented header text in pause menu
- style pause menu exit button in red
- adjust settings button size & placement
- allow tapping outside the modal to continue

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68811fe138288332b537b0bf85be79f2