### PR TITLE
Use logo image on landing page

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -17,10 +17,14 @@ body {
 }
 
 .title {
-  font-size: 3rem;
-  color: #ffffff;
   margin-bottom: 0.5rem;
-  text-shadow: 1px 1px 2px rgba(0,0,0,0.3);
+}
+
+.title-logo {
+  display: block;
+  width: clamp(200px, 60vw, 350px);
+  height: auto;
+  margin: 0 auto;
 }
 
 .tagline {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <div class="flying-tile" aria-hidden="true"></div>
   <div class="flying-tile" aria-hidden="true"></div>
   <div class="container">
-    <h1 class="title">Mes Premiers Mots</h1>
+    <h1 class="title"><img src="78A3A8C0-8F21-4850-82E8-926D573B5820.png" alt="Mes Premiers Mots" class="title-logo"></h1>
     <p class="tagline">Bienvenue !</p>
     <div class="buttons">
       <button id="play" class="btn play">Jouer</button>


### PR DESCRIPTION
## Summary
- replace text title with logo image
- style logo image on landing page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883f84562ec833285283cea68f8c119