### PR TITLE
Fix tile shake timing and flash slot letter

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -75,6 +75,9 @@ body {
 .slot.wrong {
   animation: flash-red 0.3s;
 }
+.slot.flash-letter {
+  animation: flash-letter-red 0.3s;
+}
 .next {
   margin-top: 2rem;
   position: fixed;
@@ -199,6 +202,11 @@ body {
 @keyframes flash-red {
   from { box-shadow: 0 0 0 4px red; }
   to { box-shadow: 0 0 0 4px transparent; }
+}
+
+@keyframes flash-letter-red {
+  from { color: red; }
+  to { color: #000; }
 }
 
 /* Word history at bottom of screen */

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -53,6 +53,7 @@ export function setupDragDrop(slots, tiles, onComplete) {
       tile.style.transition = 'transform 0.2s';
       tile.style.transform = '';
       clearHover();
+      let wrongDrop = false;
       if (dropSlot && !dropSlot.classList.contains('filled')) {
         const letter = tile.textContent;
         if (letter === dropSlot.dataset.letter) {
@@ -67,15 +68,21 @@ export function setupDragDrop(slots, tiles, onComplete) {
             onComplete();
           }
         } else {
-          dropSlot.classList.add('wrong');
-          tile.classList.add('shake');
+          wrongDrop = true;
+          dropSlot.classList.add('wrong', 'flash-letter');
           playError();
-          dropSlot.addEventListener('animationend', () => dropSlot.classList.remove('wrong'), { once: true });
+          dropSlot.addEventListener('animationend', () => {
+            dropSlot.classList.remove('wrong');
+            dropSlot.classList.remove('flash-letter');
+          }, { once: true });
           tile.addEventListener('animationend', () => tile.classList.remove('shake'), { once: true });
         }
       }
       tile.addEventListener('transitionend', () => {
         tile.style.transition = '';
+        if (wrongDrop) {
+          tile.classList.add('shake');
+        }
       }, { once: true });
       tile.classList.remove('active');
     };


### PR DESCRIPTION
## Summary
- shake animation was jerky because it ran while the tile transitioned back home
- start shaking only after the transition ends
- flash the slot letter in red when a wrong letter is dropped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884a1b95bf48332b519bfc20b1fb053