### PR TITLE
Fix drag drop detection

### DIFF
--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -48,6 +48,10 @@ export function setupDragDrop(slots, tiles, onComplete) {
       tile.removeEventListener('pointermove', move);
       tile.removeEventListener('pointerup', end);
       tile.removeEventListener('pointercancel', end);
+      // Ensure the tile position reflects the final pointer location.
+      // Fast drags may not fire a last pointermove, so manually update
+      // using the pointerup coordinates before evaluating the drop.
+      move(e);
       tile.releasePointerCapture(e.pointerId);
       const dropSlot = intersectingSlot(tile);
       tile.style.transition = 'transform 0.2s';


### PR DESCRIPTION
## Summary
- ensure pointer release updates tile position before testing drop target

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884a7ba83888332b4fcc896f48a6cbf