### PR TITLE
Update landing page layout

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -1,6 +1,6 @@
 /* Landing page styling */
 body {
-  background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+  background: #f7f7f5;
   height: 100vh;
   display: flex;
   align-items: center;
@@ -20,9 +20,25 @@ body {
 
 /* animated heading */
 .title {
-  margin-bottom: 0.5rem;
-  font-size: clamp(2.5rem, 8vw, 4rem);
+  margin-bottom: 1.5rem;
   animation: color-cycle 8s linear infinite;
+}
+
+.title span {
+  display: block;
+  line-height: 1;
+}
+
+.title .small {
+  font-size: clamp(1.5rem, 5vw, 2.5rem);
+}
+
+.title .medium {
+  font-size: clamp(2.5rem, 7vw, 3.5rem);
+}
+
+.title .large {
+  font-size: clamp(3.5rem, 9vw, 5rem);
 }
 
 @keyframes color-cycle {
@@ -32,16 +48,12 @@ body {
   100% { color: #ff9a9e; }
 }
 
-.tagline {
-  font-size: 1.2rem;
-  color: #ffffff;
-  margin-bottom: 2rem;
-}
 
 .buttons {
   display: flex;
+  flex-direction: column;
   gap: 1rem;
-  justify-content: center;
+  align-items: center;
 }
 
 .btn {

--- a/index.html
+++ b/index.html
@@ -18,14 +18,17 @@
   <div class="flying-tile" aria-hidden="true"></div>
   <div class="flying-tile" aria-hidden="true"></div>
   <div class="flying-tile" aria-hidden="true"></div>
-  <div class="container">
-    <h1 class="title bungee-regular">Mes premiers mots</h1>
-    <p class="tagline">Bienvenue !</p>
-    <div class="buttons">
-      <button id="play" class="btn play">Jouer</button>
-      <button id="options" class="btn options">Options</button>
+    <div class="container">
+      <h1 class="title bungee-regular">
+        <span class="small">Mes</span>
+        <span class="medium">Premiers</span>
+        <span class="large">MOTS</span>
+      </h1>
+      <div class="buttons">
+        <button id="play" class="btn play">Jouer</button>
+        <button id="options" class="btn options">Options</button>
+      </div>
     </div>
-  </div>
   <div class="version">2025-07-22 10:45 CEST</div>
   <script src="js/landing.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- redesign landing title as 3-row logo
- drop tagline
- use off‑white background
- stack play/options buttons vertically

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688522e3ae0083328e7eb4fe44157b42