### PR TITLE
Adjust landing layout for mobile

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -9,6 +9,20 @@ body {
   overflow: hidden;
 }
 
+@media (orientation: portrait) {
+  body {
+    justify-content: flex-start;
+    padding-top: 30vh;
+  }
+}
+
+@media (orientation: landscape) {
+  body {
+    justify-content: center;
+    padding-top: 0;
+  }
+}
+
 .container {
   text-align: center;
   padding: 2rem;
@@ -30,15 +44,15 @@ body {
 }
 
 .title .small {
-  font-size: clamp(1.5rem, 5vw, 2.5rem);
+  font-size: clamp(2rem, 6vw, 3rem);
 }
 
 .title .medium {
-  font-size: clamp(2.5rem, 7vw, 3.5rem);
+  font-size: clamp(3rem, 8vw, 4.5rem);
 }
 
 .title .large {
-  font-size: clamp(3.5rem, 9vw, 5rem);
+  font-size: clamp(4rem, 10vw, 6rem);
 }
 
 @keyframes color-cycle {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>Mes Premiers Mots</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- enlarge landing page title
- push page content higher in portrait
- disable viewport scaling on iOS

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688545c44d748332973b89e97c572088