### PR TITLE
Update title placement and color cycle

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -5,20 +5,21 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   position: relative;
   overflow: hidden;
+  padding-top: 30vh;
 }
 
 @media (orientation: portrait) {
   body {
-    padding-top: 20vh;
+    padding-top: 30vh;
   }
 }
 
 @media (orientation: landscape) {
   body {
-    padding-top: 0;
+    padding-top: 20vh;
   }
 }
 
@@ -55,10 +56,10 @@ body {
 }
 
 @keyframes color-cycle {
-  0% { color: #ff3333; }
-  33% { color: #ff7700; }
-  66% { color: #ffee00; }
-  100% { color: #ff3333; }
+  0% { color: #d2042d; }
+  33% { color: #ff6600; }
+  66% { color: #ffd700; }
+  100% { color: #d2042d; }
 }
 
 


### PR DESCRIPTION
## Summary
- position the title higher on the landing screen
- shift button placement accordingly
- revise title color animation to cycle through yellow, orange and red

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68854fa1a75c8332b86ee982c6f6aba7