### PR TITLE
Landing page style tweaks

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -34,8 +34,8 @@ body {
 
 /* animated heading */
 .title {
-  margin-bottom: 1.5rem;
-  animation: color-cycle 24s linear infinite;
+  margin-bottom: 0;
+  color: #ff9966;
 }
 
 .title span {
@@ -55,7 +55,7 @@ body {
   display: flex;
   justify-content: center;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  margin-top: 0;
 }
 
 .title-tile {
@@ -84,6 +84,7 @@ body {
   flex-direction: column;
   gap: 1rem;
   align-items: center;
+  margin-top: 20vh;
 }
 
 .btn {
@@ -112,15 +113,13 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 60px;
-  height: 60px;
-  background: #fdfdfd;
-  border-radius: 10px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  width: 90px;
+  height: 90px;
+  background: transparent;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  font-size: 3rem;
   color: #000;
   z-index: 0;
   pointer-events: none;

--- a/js/landing.js
+++ b/js/landing.js
@@ -6,7 +6,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   const options = document.getElementById('options');
   const tiles = Array.from(document.querySelectorAll('.flying-tile'));
 
-  const size = 60; // match CSS
+  const size = 90; // match CSS
 
   const wordData = await fetch('game/data/words-fr.json').then((r) => r.json());
   const emojis = wordData.map((w) => w.emoji);


### PR DESCRIPTION
## Summary
- tone down the title with a static peach color
- tighten spacing between the heading and letter tiles
- enlarge floating emoji and remove tile styling
- drop buttons lower on the page

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68865cbbd6f083329ff0bb6498432139