### PR TITLE
Fix button fonts and tile overlap

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -88,7 +88,8 @@ body {
 }
 
 .btn {
-  font-size: 1rem;
+  font-family: "Titan One", sans-serif;
+  font-size: 1.25rem;
   padding: 0.75rem 1.5rem;
   border: none;
   border-radius: 8px;

--- a/game/css/game.css
+++ b/game/css/game.css
@@ -4,7 +4,7 @@
   --tile-height: clamp(50px, 12vw, 100px);
   --tile-font: clamp(2rem, 5vw, 3rem);
   --picture-size: clamp(6.5rem, 20vw, 12rem);
-  --btn-font: clamp(1rem, 3vw, 1.5rem);
+  --btn-font: clamp(1.2rem, 3vw, 1.6rem);
   --next-font: clamp(2rem, 5vw, 3rem);
 }
 
@@ -93,6 +93,7 @@ body {
 }
 
 .btn {
+  font-family: "Titan One", sans-serif;
   font-size: var(--btn-font);
   padding: 0.75rem 1.5rem;
   border: none;
@@ -236,6 +237,7 @@ body {
   right: 0.25rem;
   background: none;
   border: none;
+  font-family: "Titan One", sans-serif;
   font-size: clamp(1.6rem, 4vw, 3rem);
   cursor: pointer;
   z-index: 3;

--- a/game/index.html
+++ b/game/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Jeu - Mes Premiers Mots</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Titan+One&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/base.css">
   <link rel="stylesheet" href="css/game.css">
 </head>

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -334,6 +334,7 @@ function showWord(wordObj) {
   const slots = createSlots(wordObj.word);
   const tiles = createTiles(wordObj.word);
   currentTiles = tiles;
+  document.fonts.ready.then(repositionTiles);
   const nextBtn = document.getElementById('next');
   nextBtn.style.display = 'none';
   document.getElementById('message').classList.remove('show');
@@ -373,6 +374,7 @@ window.addEventListener('DOMContentLoaded', () => {
   renderHistory();
   startGame();
   repositionTiles();
+  document.fonts.ready.then(repositionTiles);
 
   const settingsBtn = document.getElementById('settings-btn');
   const continueBtn = document.getElementById('continue-btn');


### PR DESCRIPTION
## Summary
- apply Titan One font to buttons on landing page and game screen
- load Titan One font on the game page
- slightly increase button font sizes
- reposition tiles once fonts have loaded to avoid overlap

## Testing
- `npm test` *(fails: ENOENT: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886630aa7508332978c952bd46a5120