### PR TITLE
Fix tile overlap by giving container width

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -49,6 +49,7 @@ body {
   position: relative;
   height: 35vh;
   max-height: clamp(300px, 40vh, 500px);
+  width: 100%;
 }
 .tile {
   width: var(--tile-width);
@@ -297,6 +298,7 @@ body {
   }
   .tiles {
     height: 50vh;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the tile area spans the full width of the page in both orientations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68867dc4e48083328de657bf906dff37