### PR TITLE
Add word progress indicators

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -233,8 +233,20 @@ body {
   pointer-events: none;
 }
 
-.history-emoji {
+.history-emoji,
+.history-placeholder {
+  width: clamp(1.5rem, 3vw, 2.5rem);
+  height: clamp(1.5rem, 3vw, 2.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.history-placeholder {
+  border: 2px dashed #555;
+  border-radius: 4px;
+  box-sizing: border-box;
 }
 
 /* Settings button */

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -69,13 +69,17 @@ function renderHistory() {
   const container = document.getElementById('history');
   if (!container) return;
   container.innerHTML = '';
-  const recent = wordHistory.slice(-30).reverse();
-  recent.forEach((emoji) => {
+  for (let i = 0; i < sessionLimit; i++) {
     const span = document.createElement('span');
-    span.className = 'history-emoji';
-    span.textContent = emoji;
+    if (i < wordHistory.length) {
+      span.className = 'history-emoji';
+      span.textContent = wordHistory[i];
+    } else {
+      span.className = 'history-placeholder';
+      span.textContent = '';
+    }
     container.appendChild(span);
-  });
+  }
 }
 
 function addToHistory(emoji) {

--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -5,3 +5,19 @@
   display: block;
   font-size: 0.75rem;
 }
+
+.mode-btn .preview {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2px;
+  margin-bottom: 0.25rem;
+}
+
+.preview-slot {
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 2px dashed #fff;
+  border-radius: 2px;
+  box-sizing: border-box;
+}

--- a/mode/index.html
+++ b/mode/index.html
@@ -15,9 +15,18 @@
   <div class="container">
     <h1 class="title titan-one-regular">Choisis un mode</h1>
     <div class="buttons modes">
-      <button class="btn play mode-btn" data-count="7">Court<br><small>7 mots</small></button>
-      <button class="btn play mode-btn" data-count="15">Moyen<br><small>15 mots</small></button>
-      <button class="btn play mode-btn" data-count="30">Long<br><small>30 mots</small></button>
+      <button class="btn play mode-btn" data-count="7">
+        <div class="preview" aria-hidden="true"></div>
+        Court<br><small>7 mots</small>
+      </button>
+      <button class="btn play mode-btn" data-count="15">
+        <div class="preview" aria-hidden="true"></div>
+        Moyen<br><small>15 mots</small>
+      </button>
+      <button class="btn play mode-btn" data-count="30">
+        <div class="preview" aria-hidden="true"></div>
+        Long<br><small>30 mots</small>
+      </button>
       <button id="back" class="btn options">Retour</button>
     </div>
   </div>

--- a/mode/js/mode-select.js
+++ b/mode/js/mode-select.js
@@ -1,7 +1,15 @@
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.mode-btn').forEach((btn) => {
+    const count = parseInt(btn.dataset.count, 10);
+    const preview = btn.querySelector('.preview');
+    if (preview) {
+      for (let i = 0; i < count; i++) {
+        const span = document.createElement('span');
+        span.className = 'preview-slot';
+        preview.appendChild(span);
+      }
+    }
     btn.addEventListener('click', () => {
-      const count = parseInt(btn.dataset.count, 10);
       sessionStorage.setItem('wordLimit', String(count));
       window.location.href = '../game/';
     });


### PR DESCRIPTION
## Summary
- show open progress spots for each remaining word in the game
- fill a spot with each found emoji
- preview mode length with the same visual spots on the mode screen

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6886ae6bde848332a4e947520abcbb1e