### PR TITLE
Enhance new word preview

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -41,7 +41,12 @@ body {
   color: #000;
 }
 .slot.preview {
-  opacity: 0.3;
+  opacity: 0.5;
+  border: 1px solid #bbb;
+  width: calc(var(--tile-width) * 0.85);
+  height: calc(var(--tile-height) * 0.85);
+  font-size: calc(var(--tile-font) * 0.85);
+  border-radius: 4px;
 }
 .slot.filled {
   border-style: solid;

--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -11,13 +11,13 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: 2px;
-  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 .preview-slot {
-  width: 0.8rem;
-  height: 0.8rem;
-  border: 2px dashed #fff;
+  width: 0.6rem;
+  height: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.6);
   border-radius: 2px;
   box-sizing: border-box;
 }

--- a/mode/index.html
+++ b/mode/index.html
@@ -16,16 +16,16 @@
     <h1 class="title titan-one-regular">Choisis un mode</h1>
     <div class="buttons modes">
       <button class="btn play mode-btn" data-count="7">
-        <div class="preview" aria-hidden="true"></div>
         Court<br><small>7 mots</small>
+        <div class="preview" aria-hidden="true"></div>
       </button>
       <button class="btn play mode-btn" data-count="15">
-        <div class="preview" aria-hidden="true"></div>
         Moyen<br><small>15 mots</small>
+        <div class="preview" aria-hidden="true"></div>
       </button>
       <button class="btn play mode-btn" data-count="30">
-        <div class="preview" aria-hidden="true"></div>
         Long<br><small>30 mots</small>
+        <div class="preview" aria-hidden="true"></div>
       </button>
       <button id="back" class="btn options">Retour</button>
     </div>


### PR DESCRIPTION
## Summary
- lighten styles for preview word tiles
- shrink and recolor mode previews
- move mode previews below word counts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887250fa844833281845104b81bc077