### PR TITLE
Add infinite mode

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -6,7 +6,12 @@ let confettiInterval;
 let bounceCount = 0;
 let bounceHandler;
 let currentTiles = [];
-let sessionLimit = parseInt(sessionStorage.getItem('wordLimit') || '30', 10);
+function parseLimit(value) {
+  if (!value) return 30;
+  return value === 'inf' ? Infinity : parseInt(value, 10);
+}
+
+let sessionLimit = parseLimit(sessionStorage.getItem('wordLimit'));
 let wordsPlayed = 0;
 
 function repositionTiles() {
@@ -69,7 +74,8 @@ function renderHistory() {
   const container = document.getElementById('history');
   if (!container) return;
   container.innerHTML = '';
-  for (let i = 0; i < sessionLimit; i++) {
+  const limit = sessionLimit === Infinity ? wordHistory.length : sessionLimit;
+  for (let i = 0; i < limit; i++) {
     const span = document.createElement('span');
     if (i < wordHistory.length) {
       span.className = 'history-emoji';
@@ -371,7 +377,7 @@ function showWord(wordObj) {
   nextBtn.textContent = 'Mot suivant \u27A1\uFE0F';
   nextBtn.onclick = () => {
     wordsPlayed++;
-    if (wordsPlayed >= sessionLimit) {
+    if (sessionLimit !== Infinity && wordsPlayed >= sessionLimit) {
       endGame();
     } else {
       startGame();
@@ -397,7 +403,7 @@ function closeSettings() {
 
 window.addEventListener('DOMContentLoaded', () => {
   wordsPlayed = 0;
-  sessionLimit = parseInt(sessionStorage.getItem('wordLimit') || '30', 10);
+  sessionLimit = parseLimit(sessionStorage.getItem('wordLimit'));
   loadHistory();
   renderHistory();
   startGame();

--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -7,17 +7,6 @@
 }
 
 .mode-btn .preview {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 2px;
   margin-top: 0.25rem;
-}
-
-.preview-slot {
-  width: 0.6rem;
-  height: 0.6rem;
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  border-radius: 2px;
-  box-sizing: border-box;
+  font-size: 1.5rem;
 }

--- a/mode/index.html
+++ b/mode/index.html
@@ -15,16 +15,20 @@
   <div class="container">
     <h1 class="title titan-one-regular">Choisis un mode</h1>
     <div class="buttons modes">
-      <button class="btn play mode-btn" data-count="7">
+      <button class="btn play mode-btn" data-count="7" data-emoji="🌱">
         Court<br><small>7 mots</small>
         <div class="preview" aria-hidden="true"></div>
       </button>
-      <button class="btn play mode-btn" data-count="15">
+      <button class="btn play mode-btn" data-count="15" data-emoji="🌿">
         Moyen<br><small>15 mots</small>
         <div class="preview" aria-hidden="true"></div>
       </button>
-      <button class="btn play mode-btn" data-count="30">
+      <button class="btn play mode-btn" data-count="30" data-emoji="🌳">
         Long<br><small>30 mots</small>
+        <div class="preview" aria-hidden="true"></div>
+      </button>
+      <button class="btn play mode-btn" data-count="inf" data-emoji="♾️">
+        Infini<br><small>sans fin</small>
         <div class="preview" aria-hidden="true"></div>
       </button>
       <button id="back" class="btn options">Retour</button>

--- a/mode/js/mode-select.js
+++ b/mode/js/mode-select.js
@@ -1,16 +1,12 @@
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.mode-btn').forEach((btn) => {
-    const count = parseInt(btn.dataset.count, 10);
+    const countAttr = btn.dataset.count;
     const preview = btn.querySelector('.preview');
     if (preview) {
-      for (let i = 0; i < count; i++) {
-        const span = document.createElement('span');
-        span.className = 'preview-slot';
-        preview.appendChild(span);
-      }
+      preview.textContent = btn.dataset.emoji || '';
     }
     btn.addEventListener('click', () => {
-      sessionStorage.setItem('wordLimit', String(count));
+      sessionStorage.setItem('wordLimit', countAttr);
       window.location.href = '../game/';
     });
   });


### PR DESCRIPTION
## Summary
- add infinite mode option on mode select screen
- show mode previews with emojis
- handle infinite gameplay loop in JS

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887564efde8833294a63d846aa5f039