### PR TITLE
Add loading screen with asset prefetch

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -110,6 +110,42 @@ body {
   opacity: 0.9;
 }
 
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: #f7f7f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  z-index: 5;
+}
+
+.loading-overlay.hidden {
+  display: none;
+}
+
+.loading-bar {
+  width: 60%;
+  height: 10px;
+  background: #ddd;
+  border-radius: 5px;
+  overflow: hidden;
+  margin: 1rem auto 0;
+}
+
+.loading-progress {
+  height: 100%;
+  width: 0;
+  background: #4caf50;
+  transition: width 0.2s ease;
+}
+
+.loading-text {
+  margin-top: 0.5rem;
+  font-family: "Nunito", sans-serif;
+}
+
 .flying-tile {
   position: fixed;
   top: 0;

--- a/index.html
+++ b/index.html
@@ -34,6 +34,22 @@
         <button id="options" class="btn options">Options</button>
       </div>
     </div>
+  <div id="loading-overlay" class="loading-overlay hidden">
+    <div class="container">
+      <h1 class="title titan-one-regular">
+        <span class="small">MES</span>
+        <span class="medium">PREMIERS</span>
+      </h1>
+      <div class="title-tiles">
+        <div class="title-tile">M</div>
+        <div class="title-tile">O</div>
+        <div class="title-tile">T</div>
+        <div class="title-tile">S</div>
+      </div>
+      <div class="loading-bar"><div id="loading-progress" class="loading-progress"></div></div>
+      <div id="loading-text" class="loading-text">0%</div>
+    </div>
+  </div>
   <div class="version">2025-07-22 10:45 CEST</div>
   <script src="js/landing.js"></script>
 </body>

--- a/js/landing.js
+++ b/js/landing.js
@@ -4,6 +4,9 @@ window.addEventListener('DOMContentLoaded', async () => {
   sessionStorage.removeItem('wordHistory');
   const play = document.getElementById('play');
   const options = document.getElementById('options');
+  const overlay = document.getElementById('loading-overlay');
+  const progressBar = document.getElementById('loading-progress');
+  const progressText = document.getElementById('loading-text');
   const tiles = Array.from(document.querySelectorAll('.flying-tile'));
 
   const size = 90; // match CSS
@@ -17,6 +20,38 @@ window.addEventListener('DOMContentLoaded', async () => {
     (Math.random() * 0.4 + 0.2) * 1.2 * (Math.random() < 0.5 ? -1 : 1);
 
   const states = [];
+
+  const resources = [
+    'mode/index.html',
+    'mode/css/mode.css',
+    'mode/js/mode-select.js',
+    'game/index.html',
+    'game/css/game.css',
+    'game/js/main.mjs',
+    'game/js/drag-drop.mjs',
+    'game/js/word-check.mjs',
+    'game/js/audio.mjs',
+    'game/data/words-fr.json',
+    'settings/index.html',
+    'settings/css/settings.css'
+  ];
+
+  async function prefetchResources() {
+    overlay.classList.remove('hidden');
+    let loaded = 0;
+    for (const url of resources) {
+      try {
+        await fetch(url);
+      } catch (e) {
+        // ignore failures (offline or 404)
+      }
+      loaded++;
+      const pct = Math.round((loaded / resources.length) * 100);
+      progressBar.style.width = pct + '%';
+      progressText.textContent = pct + '%';
+    }
+    overlay.classList.add('hidden');
+  }
 
   const nonOverlappingPosition = () => {
     for (let attempt = 0; attempt < 50; attempt++) {
@@ -117,6 +152,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   };
 
   requestAnimationFrame(step);
+  prefetchResources();
 
   play.addEventListener('click', () => {
     window.location.href = 'mode/';


### PR DESCRIPTION
## Summary
- add a loading overlay to the landing page
- style progress bar for the loader
- preload game, mode and settings pages via JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes htmlhint "**/*.html"`

------
https://chatgpt.com/codex/tasks/task_e_68875abca1f48332a74fc99a408f4d56