### PR TITLE
Fix mode screen vertical layout

### DIFF
--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -1,12 +1,21 @@
 .modes {
-  margin-top: 10vh;
+  margin-top: 5vh;
 }
+
+.mode-btn {
+  position: relative;
+  padding-right: 2.25rem;
+}
+
 .mode-btn small {
   display: block;
   font-size: 0.75rem;
 }
 
 .mode-btn .preview {
-  margin-top: 0.25rem;
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
   font-size: 1.5rem;
+  margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- improve layout of mode selection buttons for small screens
- tuck the emoji preview inside the button
- reduce spacing above the mode buttons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68876334a56c8332aecc351c9ed170c0