### PR TITLE
Fix game end detection and refine touch UX

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -9,6 +9,7 @@ body {
   position: relative;
   overflow: hidden;
   padding-top: 10vh;
+  user-select: none;
 }
 
 @media (orientation: portrait) {
@@ -69,6 +70,7 @@ body {
   justify-content: center;
   font-size: 2rem;
   color: #000;
+  user-select: none;
 }
 
 @keyframes color-cycle {
@@ -160,6 +162,9 @@ body {
   color: #000;
   z-index: 0;
   pointer-events: none;
+  overflow: hidden;
+  line-height: 1;
+  user-select: none;
 }
 
 /* discreet version label */

--- a/game/css/game.css
+++ b/game/css/game.css
@@ -16,6 +16,7 @@ body {
   flex-direction: column;
   align-items: center;
   background: #f7f7f5;
+  user-select: none;
 }
 #picture {
   /* enlarge the emoji display */
@@ -39,6 +40,7 @@ body {
   align-items: center;
   justify-content: center;
   color: #000;
+  user-select: none;
 }
 .slot.preview {
   opacity: 0.3;
@@ -64,6 +66,7 @@ body {
   font-size: var(--tile-font);
   cursor: grab;
   position: absolute;
+  user-select: none;
 }
 .tile.active {
   box-shadow: 0 6px 10px rgba(0,0,0,0.4);
@@ -241,6 +244,7 @@ body {
   align-items: center;
   justify-content: center;
   font-size: clamp(1.3rem, 2.5vw, 2.1rem);
+  user-select: none;
 }
 
 .history-placeholder {

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -370,18 +370,18 @@ function showWord(wordObj) {
       animateWordReveal(slots).then(() => {
         addToHistory(wordObj.emoji);
         celebrate();
-        nextBtn.style.display = 'inline-block';
+        wordsPlayed++;
+        if (sessionLimit !== Infinity && wordsPlayed >= sessionLimit) {
+          endGame();
+        } else {
+          nextBtn.style.display = 'inline-block';
+        }
       });
     }
   });
   nextBtn.textContent = 'Mot suivant \u27A1\uFE0F';
   nextBtn.onclick = () => {
-    wordsPlayed++;
-    if (sessionLimit !== Infinity && wordsPlayed >= sessionLimit) {
-      endGame();
-    } else {
-      startGame();
-    }
+    startGame();
   };
 }
 

--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -10,6 +10,7 @@
 
 .mode-btn {
   position: relative;
+  user-select: none;
 }
 
 .mode-btn small {
@@ -19,4 +20,5 @@
 
 .preview {
   font-size: 2.25rem;
+  user-select: none;
 }


### PR DESCRIPTION
## Summary
- end the game right after the final word is solved
- prevent text selection on touch elements
- ensure flying emoji tiles don't show stray pixels

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887a653faf48332a95aedbc6b97c4a1