### PR TITLE
Add celebration page after completing session

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -1,0 +1,36 @@
+body {
+  text-align: center;
+  padding-top: 3rem;
+  background: #f7f7f5;
+}
+
+.emojis {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin: 2rem auto;
+  max-width: 90vw;
+}
+
+.emoji {
+  font-size: clamp(2.5rem, 8vw, 4rem);
+  display: inline-block;
+  animation: dance 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes dance {
+  from { transform: translateY(0) rotate(-10deg); }
+  to { transform: translateY(-20%) rotate(10deg); }
+}
+
+.btn {
+  font-family: "Nunito", sans-serif;
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background-color: #4caf50;
+  color: #fff;
+}

--- a/celebration/index.html
+++ b/celebration/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bravo !</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Titan+One&family=Nunito:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/base.css">
+  <link rel="stylesheet" href="css/celebration.css">
+</head>
+<body>
+  <h1 class="title titan-one-regular">Bravo !</h1>
+  <div id="emoji-container" class="emojis"></div>
+  <button id="menu" class="btn play">Menu principal ↩️</button>
+  <script type="module" src="js/celebration.js"></script>
+</body>
+</html>

--- a/celebration/js/celebration.js
+++ b/celebration/js/celebration.js
@@ -1,0 +1,19 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('emoji-container');
+  const menuBtn = document.getElementById('menu');
+  const stored = sessionStorage.getItem('wordHistory');
+  const emojis = stored ? JSON.parse(stored) : [];
+
+  emojis.forEach((e) => {
+    const span = document.createElement('span');
+    span.className = 'emoji';
+    span.textContent = e;
+    container.appendChild(span);
+  });
+
+  menuBtn.addEventListener('click', () => {
+    sessionStorage.removeItem('wordLimit');
+    sessionStorage.removeItem('wordHistory');
+    window.location.href = '../';
+  });
+});

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -309,17 +309,10 @@ function dropUnusedTiles() {
 }
 
 function endGame() {
-  const nextBtn = document.getElementById('next');
-  const msg = document.getElementById('message');
-  msg.textContent = 'Fin de la partie !';
-  msg.classList.add('show');
-  nextBtn.textContent = 'Menu principal \u21A9\uFE0F';
-  nextBtn.style.display = 'inline-block';
-  nextBtn.onclick = () => {
-    sessionStorage.removeItem('wordLimit');
-    sessionStorage.removeItem('wordHistory');
-    window.location.href = '../';
-  };
+  // give the player a brief moment to enjoy the final word animation
+  setTimeout(() => {
+    window.location.href = '../celebration/';
+  }, 800);
 }
 
 async function animateWordReveal(slots) {

--- a/js/landing.js
+++ b/js/landing.js
@@ -33,7 +33,10 @@ window.addEventListener('DOMContentLoaded', async () => {
     'game/js/audio.mjs',
     'game/data/words-fr.json',
     'settings/index.html',
-    'settings/css/settings.css'
+    'settings/css/settings.css',
+    'celebration/index.html',
+    'celebration/css/celebration.css',
+    'celebration/js/celebration.js'
   ];
 
   async function prefetchResources() {


### PR DESCRIPTION
## Summary
- add celebration page to show dancing emojis after a session ends
- redirect to the celebration page from the game
- prefetch celebration assets on the landing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b0b8b8988332867c9b12952b7b7f