### PR TITLE
Fix celebration screen confetti

### DIFF
--- a/celebration/js/celebration.js
+++ b/celebration/js/celebration.js
@@ -1,4 +1,5 @@
-import { startConfetti } from '../js/confetti.js';
+// Use the shared confetti script from the project root.
+import { startConfetti } from '../../js/confetti.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('emoji-container');


### PR DESCRIPTION
## Summary
- fix broken import path for confetti on the celebration page

## Testing
- `grep -n "startConfetti" -R | head`


------
https://chatgpt.com/codex/tasks/task_e_6887bd84125c8332b9d73f27d9a851bf