### PR TITLE
Enhance mode selection screen

### DIFF
--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -1,24 +1,51 @@
 .modes {
   margin-top: 5vh;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  justify-items: center;
 }
 
 .mode-option {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  background: #fdfdfd;
+  border-radius: 12px;
+  padding: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .mode-btn {
   position: relative;
   user-select: none;
+  width: 100%;
+  background-color: var(--clr, #4caf50);
+  color: #fff;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.mode-btn:hover {
+  transform: scale(1.05);
+}
+
+.mode-btn.selected {
+  animation: pop 0.3s ease;
+}
+
+@keyframes pop {
+  0% { transform: scale(1); box-shadow: none; }
+  50% { transform: scale(1.1); box-shadow: 0 0 10px rgba(0,0,0,0.2); }
+  100% { transform: scale(1); box-shadow: none; }
 }
 
 .mode-btn small {
   display: block;
-  font-size: 0.75rem;
+  font-size: 1rem;
 }
 
 .preview {
-  font-size: 2.25rem;
+  font-size: 3rem;
   user-select: none;
+  line-height: 1;
 }

--- a/mode/index.html
+++ b/mode/index.html
@@ -16,34 +16,34 @@
     <h1 class="title titan-one-regular">Choisis un mode</h1>
     <div class="buttons modes">
       <div class="mode-option">
-        <button class="btn play mode-btn" data-count="1" data-emoji="⚡">
+        <div class="preview" aria-hidden="true"></div>
+        <button class="btn play mode-btn" data-count="1" data-emoji="⚡" style="--clr:#ffca28">
           Test<br><small>1 mot</small>
         </button>
-        <div class="preview" aria-hidden="true"></div>
       </div>
       <div class="mode-option">
-        <button class="btn play mode-btn" data-count="7" data-emoji="🌱">
+        <div class="preview" aria-hidden="true"></div>
+        <button class="btn play mode-btn" data-count="7" data-emoji="🌱" style="--clr:#81c784">
           Court<br><small>7 mots</small>
         </button>
-        <div class="preview" aria-hidden="true"></div>
       </div>
       <div class="mode-option">
-        <button class="btn play mode-btn" data-count="15" data-emoji="🌿">
+        <div class="preview" aria-hidden="true"></div>
+        <button class="btn play mode-btn" data-count="15" data-emoji="🌿" style="--clr:#4caf50">
           Moyen<br><small>15 mots</small>
         </button>
-        <div class="preview" aria-hidden="true"></div>
       </div>
       <div class="mode-option">
-        <button class="btn play mode-btn" data-count="30" data-emoji="🌳">
+        <div class="preview" aria-hidden="true"></div>
+        <button class="btn play mode-btn" data-count="30" data-emoji="🌳" style="--clr:#42a5f5">
           Long<br><small>30 mots</small>
         </button>
-        <div class="preview" aria-hidden="true"></div>
       </div>
       <div class="mode-option">
-        <button class="btn play mode-btn" data-count="inf" data-emoji="♾️">
+        <div class="preview" aria-hidden="true"></div>
+        <button class="btn play mode-btn" data-count="inf" data-emoji="♾️" style="--clr:#ab47bc">
           Infini<br><small>sans fin</small>
         </button>
-        <div class="preview" aria-hidden="true"></div>
       </div>
       <button id="back" class="btn options">Retour</button>
     </div>

--- a/mode/js/mode-select.js
+++ b/mode/js/mode-select.js
@@ -1,13 +1,16 @@
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.mode-btn').forEach((btn) => {
     const countAttr = btn.dataset.count;
-    const preview = btn.nextElementSibling;
-    if (preview && preview.classList.contains('preview')) {
+    const preview = btn.parentElement.querySelector('.preview');
+    if (preview) {
       preview.textContent = btn.dataset.emoji || '';
     }
     btn.addEventListener('click', () => {
       sessionStorage.setItem('wordLimit', countAttr);
-      window.location.href = '../game/';
+      btn.classList.add('selected');
+      setTimeout(() => {
+        window.location.href = '../game/';
+      }, 300);
     });
   });
   document.getElementById('back').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- color-code each mode option and display the emoji above the button
- arrange mode buttons in a responsive grid
- add hover/selection animations and enlarge the word-count label
- delay navigation briefly when a mode is picked so the animation is visible

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688882dcdf3c8332a62b5b52433ab040