### PR TITLE
Reposition mode selection elements

### DIFF
--- a/mode/css/mode.css
+++ b/mode/css/mode.css
@@ -1,5 +1,5 @@
 .modes {
-  margin-top: 5vh;
+  margin-top: 4vh;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 1rem;
@@ -48,4 +48,23 @@
   font-size: 3rem;
   user-select: none;
   line-height: 1;
+}
+
+body {
+  height: auto;
+  min-height: 100dvh;
+  overflow-y: auto;
+  padding-top: 2vh;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+.back-btn {
+  margin-top: auto;
+  align-self: center;
+  margin-bottom: 2rem;
 }

--- a/mode/index.html
+++ b/mode/index.html
@@ -14,7 +14,7 @@
 <body>
   <div class="container">
     <h1 class="title titan-one-regular">Choisis un mode</h1>
-    <div class="buttons modes">
+    <div class="modes">
       <div class="mode-option">
         <div class="preview" aria-hidden="true"></div>
         <button class="btn play mode-btn" data-count="1" data-emoji="⚡" style="--clr:#ffca28">
@@ -44,9 +44,9 @@
         <button class="btn play mode-btn" data-count="inf" data-emoji="♾️" style="--clr:#ab47bc">
           Infini<br><small>sans fin</small>
         </button>
+        </div>
       </div>
-      <button id="back" class="btn options">Retour</button>
-    </div>
+      <button id="back" class="btn options back-btn">Retour</button>
   </div>
   <script type="module" src="js/mode-select.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- rearrange markup on the mode selection page
- move the title up and back button down
- allow vertical scrolling for the page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688889b5a5fc8332bc4aa663e1e4fd82