### PR TITLE
Update celebration screen animations

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -33,8 +33,20 @@ body {
   position: relative;
   width: 80vmin;
   height: 80vmin;
+  margin: 0 auto;
+  animation: rotateCircle 10s linear infinite;
+}
+
+#wheel {
+  width: 80vmin;
+  height: 80vmin;
   margin: 2rem auto;
-  animation: rotateCircle 20s linear infinite;
+  animation: wheelPulse 4s ease-in-out infinite;
+}
+
+@keyframes wheelPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(0.85); }
 }
 
 @keyframes rotateCircle {
@@ -61,7 +73,6 @@ body {
 .emoji {
   display: block;
   transform-origin: center;
-  animation: pulse 2s ease-in-out infinite;
 }
 
 @keyframes pulse {
@@ -78,6 +89,18 @@ body {
   cursor: pointer;
   background-color: #4caf50;
   color: #fff;
+}
+
+#menu {
+  margin-top: 2rem;
+  opacity: 0;
+  animation: menuFadeIn 0.6s ease-out forwards;
+  animation-delay: 2s;
+}
+
+@keyframes menuFadeIn {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
 }
 
 @keyframes fade-in {

--- a/celebration/index.html
+++ b/celebration/index.html
@@ -11,8 +11,8 @@
   <link rel="stylesheet" href="css/celebration.css">
 </head>
 <body>
-  <h1 class="title titan-one-regular">Bravo !</h1>
-  <div id="emoji-container" class="emojis"></div>
+  <h1 class="title titan-one-regular">BRAVO !</h1>
+  <div id="wheel"><div id="emoji-container" class="emojis"></div></div>
   <button id="menu" class="btn play">Menu principal ↩️</button>
   <script type="module" src="js/celebration.js"></script>
 </body>

--- a/celebration/js/celebration.js
+++ b/celebration/js/celebration.js
@@ -11,7 +11,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const wrappers = [];
   const radius = 35; // circle radius in vmin
-  const fontSize = Math.min(6, 40 / Math.max(emojis.length, 1));
+  const fontSize = Math.min(8, 60 / Math.max(emojis.length, 1));
 
   emojis.forEach((e, idx) => {
     const wrapper = document.createElement('span');
@@ -23,7 +23,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const span = document.createElement('span');
     span.className = 'emoji';
     span.textContent = e;
-    span.style.fontSize = `clamp(2rem, ${fontSize}vmin, 6rem)`;
+    span.style.fontSize = `clamp(3rem, ${fontSize}vmin, 8rem)`;
 
     wrapper.appendChild(span);
     container.appendChild(wrapper);
@@ -31,15 +31,13 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   const spinDuration = 600;
-  const delay = 150;
+  const overlap = 0.75; // start next spin when current is 75% done
   function wave(i = 0) {
     if (!wrappers.length) return;
     const el = wrappers[i];
     el.classList.add('spin');
-    setTimeout(() => {
-      el.classList.remove('spin');
-      setTimeout(() => wave((i + 1) % wrappers.length), delay);
-    }, spinDuration);
+    setTimeout(() => el.classList.remove('spin'), spinDuration);
+    setTimeout(() => wave((i + 1) % wrappers.length), spinDuration * overlap);
   }
 
   wave();

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -304,7 +304,7 @@ function endGame() {
     setTimeout(() => {
       window.location.href = '../celebration/';
     }, 500);
-  }, 800);
+  }, 1800);
 }
 
 async function animateWordReveal(slots) {


### PR DESCRIPTION
## Summary
- add scaling wheel wrapper and faster rotation
- tweak emoji spin overlap and size
- fade-in menu button after delay
- wait longer before switching to celebration screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888b01f06fc83329333f29bef33b3f6