### PR TITLE
Improve celebration title animation

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -18,7 +18,12 @@ body {
 .title {
   font-size: clamp(3rem, 10vw, 5rem);
   margin-bottom: 1rem;
-  animation: rainbow 5s linear infinite;
+}
+
+.title span {
+  display: inline-block;
+  animation: rainbow 3s linear infinite;
+  animation-delay: calc(var(--i) * 0.2s);
 }
 
 @keyframes rainbow {

--- a/celebration/index.html
+++ b/celebration/index.html
@@ -11,7 +11,9 @@
   <link rel="stylesheet" href="css/celebration.css">
 </head>
 <body>
-  <h1 class="title titan-one-regular">BRAVO !</h1>
+  <h1 class="title titan-one-regular" aria-label="BRAVO !">
+    <span style="--i:0">B</span><span style="--i:1">R</span><span style="--i:2">A</span><span style="--i:3">V</span><span style="--i:4">O</span><span style="--i:5">&#160;!</span>
+  </h1>
   <div id="wheel"><div id="emoji-container" class="emojis"></div></div>
   <button id="menu" class="btn play">Menu principal ↩️</button>
   <script type="module" src="js/celebration.js"></script>

--- a/css/landing.css
+++ b/css/landing.css
@@ -154,11 +154,12 @@ body {
   left: 0;
   width: 90px;
   height: 90px;
-  background: transparent;
+  background: #f7f7f5;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 3rem;
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
   color: #000;
   z-index: 0;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- animate each letter of the celebration heading with a staggered rainbow effect
- set emoji tiles to use a color emoji font and page background color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888de41d2148332a7ca5ed23ad03ba2