### PR TITLE
Ignore filled slots during hit testing

### DIFF
--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -10,6 +10,7 @@ export function setupDragDrop(slots, tiles, onComplete) {
   const intersectingSlot = (tile) => {
     const t = tile.getBoundingClientRect();
     return slots.find((slot) => {
+      if (slot.classList.contains('filled')) return false;
       const r = slot.getBoundingClientRect();
       const expandedTop = r.top - r.height * 0.25;
       const expandedBottom = r.bottom + r.height * 0.25;


### PR DESCRIPTION
## Summary
- ignore slots marked as `filled` when checking pointer intersections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688904f36cb0833283d560b6ad1e33da