### PR TITLE
Add fade transition between words

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -330,7 +330,25 @@ body.fade-out {
   animation: screen-out 0.5s ease forwards;
 }
 
+body.word-fade-out {
+  animation: word-out 0.2s ease forwards;
+}
+
+body.word-fade-in {
+  animation: word-in 0.2s ease;
+}
+
 @keyframes screen-out {
   from { opacity: 1; }
   to { opacity: 0; }
+}
+
+@keyframes word-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes word-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -366,7 +366,13 @@ function showWord(wordObj) {
   });
   nextBtn.textContent = 'Mot suivant \u27A1\uFE0F';
   nextBtn.onclick = () => {
-    startGame();
+    document.body.classList.add('word-fade-out');
+    setTimeout(() => {
+      document.body.classList.remove('word-fade-out');
+      startGame();
+      document.body.classList.add('word-fade-in');
+      setTimeout(() => document.body.classList.remove('word-fade-in'), 200);
+    }, 200);
   };
 }
 


### PR DESCRIPTION
## Summary
- add short fade animations in game CSS
- apply fade-out/in when advancing to next word

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688a3f40f72c833292b9ab7d41224aff