### PR TITLE
Add thumb-up animation to celebration

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -47,6 +47,17 @@ body {
   height: 80vmin;
   margin: 2rem auto;
   animation: wheelPulse 4s ease-in-out infinite;
+  position: relative;
+}
+
+#thumb-up {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: clamp(4rem, 20vmin, 8rem);
+  animation: pulse 2s ease-in-out infinite;
+  pointer-events: none;
 }
 
 @keyframes wheelPulse {

--- a/celebration/index.html
+++ b/celebration/index.html
@@ -14,7 +14,10 @@
   <h1 class="title titan-one-regular" aria-label="BRAVO !">
     <span style="--i:0">B</span><span style="--i:1">R</span><span style="--i:2">A</span><span style="--i:3">V</span><span style="--i:4">O</span><span style="--i:5">&#160;!</span>
   </h1>
-  <div id="wheel"><div id="emoji-container" class="emojis"></div></div>
+  <div id="wheel">
+    <span id="thumb-up" aria-hidden="true">👍</span>
+    <div id="emoji-container" class="emojis"></div>
+  </div>
   <button id="menu" class="btn play">Menu principal ↩️</button>
   <script type="module" src="js/celebration.js"></script>
   <script src="../sw-register.js"></script>


### PR DESCRIPTION
## Summary
- show a pulsing thumb-up emoji in the center of the celebration wheel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a81e1d1ac8332ba2058057e7a122a