### PR TITLE
Align thumb with spinning wheel

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -56,7 +56,8 @@ body {
   top: 50%;
   transform: translate(-50%, -50%);
   font-size: clamp(4rem, 20vmin, 8rem);
-  animation: pulse 2s ease-in-out infinite;
+  animation: pulse 1.6s ease-in-out infinite;
+  z-index: 1;
   pointer-events: none;
 }
 

--- a/celebration/index.html
+++ b/celebration/index.html
@@ -15,8 +15,9 @@
     <span style="--i:0">B</span><span style="--i:1">R</span><span style="--i:2">A</span><span style="--i:3">V</span><span style="--i:4">O</span><span style="--i:5">&#160;!</span>
   </h1>
   <div id="wheel">
-    <span id="thumb-up" aria-hidden="true">👍</span>
-    <div id="emoji-container" class="emojis"></div>
+    <div id="emoji-container" class="emojis">
+      <span id="thumb-up" aria-hidden="true">👍</span>
+    </div>
   </div>
   <button id="menu" class="btn play">Menu principal ↩️</button>
   <script type="module" src="js/celebration.js"></script>


### PR DESCRIPTION
## Summary
- keep the thumbs-up emoji anchored at the centre of the rotating emoji wheel
- speed up the thumb pulse animation by 20%
## Testing
- `npm test` (fails: could not find package.json)


------
https://chatgpt.com/codex/tasks/task_e_688b16ff7cf0833284d5f69e4875de38