### PR TITLE
fix: keep thumb emoji upright

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -93,8 +93,8 @@ body {
 }
 
 @keyframes pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.3); }
+  0%, 100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -50%) scale(1.3); }
 }
 
 .btn {

--- a/celebration/index.html
+++ b/celebration/index.html
@@ -15,9 +15,8 @@
     <span style="--i:0">B</span><span style="--i:1">R</span><span style="--i:2">A</span><span style="--i:3">V</span><span style="--i:4">O</span><span style="--i:5">&#160;!</span>
   </h1>
   <div id="wheel">
-    <div id="emoji-container" class="emojis">
-      <span id="thumb-up" aria-hidden="true">👍</span>
-    </div>
+    <span id="thumb-up" aria-hidden="true">👍</span>
+    <div id="emoji-container" class="emojis"></div>
   </div>
   <button id="menu" class="btn play">Menu principal ↩️</button>
   <script type="module" src="js/celebration.js"></script>


### PR DESCRIPTION
## Summary
- Keep thumb emoji outside the rotating emoji container so it stays upright and centered
- Preserve centering during pulse animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b191394dc83328503970d71ff4afb