### PR TITLE
Add word length option

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -379,6 +379,12 @@ function showWord(wordObj) {
 async function startGame() {
   if (wordList.length === 0) {
     wordList = await loadWords();
+    const lengthSetting = localStorage.getItem('wordLength') || 'mixed';
+    if (lengthSetting === 'short') {
+      wordList = wordList.filter((w) => w.word.length <= 5);
+    } else if (lengthSetting === 'long') {
+      wordList = wordList.filter((w) => w.word.length >= 6);
+    }
   }
   const word = nextWord();
   showWord(word);

--- a/js/landing.js
+++ b/js/landing.js
@@ -34,6 +34,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     'game/data/words-fr.json',
     'settings/index.html',
     'settings/css/settings.css',
+    'settings/js/settings.js',
     'celebration/index.html',
     'celebration/css/celebration.css',
     'celebration/js/celebration.js',

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -1,5 +1,37 @@
 /* Settings page styles */
 body {
   padding: 2rem;
-  font-family: sans-serif;
+  font-family: "Nunito", sans-serif;
+  background: #f7f7f5;
+}
+
+h1 {
+  color: #ff9966;
+  text-align: center;
+  margin-top: 0;
+}
+
+.option-group {
+  margin: 2rem 0;
+}
+
+.option-group h2 {
+  color: #ff9966;
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+}
+
+.option-group label {
+  display: block;
+  margin: 0.5rem 0;
+}
+
+.option-group .desc {
+  font-size: 0.85rem;
+  color: #555;
+  margin-left: 1.5rem;
+}
+
+.back-btn {
+  margin-top: 2rem;
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -11,8 +11,27 @@
   <link rel="stylesheet" href="css/settings.css">
 </head>
 <body>
-  <h1>Paramètres</h1>
-  <p>Page à compléter.</p>
+  <h1 class="titan-one-regular">Paramètres</h1>
+
+  <section class="option-group nunito-regular">
+    <h2>🟧 Longueur des mots</h2>
+    <label>
+      <input type="radio" name="wordLength" value="short">
+      Court seulement – <span class="desc">mots de 5 lettres ou moins</span>
+    </label>
+    <label>
+      <input type="radio" name="wordLength" value="mixed">
+      Mélangé (défaut) – <span class="desc">toutes les longueurs</span>
+    </label>
+    <label>
+      <input type="radio" name="wordLength" value="long">
+      Long seulement – <span class="desc">mots de 6 lettres ou plus</span>
+    </label>
+  </section>
+
+  <button id="back" class="btn options back-btn nunito-regular">Retour</button>
+
+  <script src="js/settings.js"></script>
   <script src="../sw-register.js"></script>
 </body>
 </html>

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -1,0 +1,17 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const radios = document.querySelectorAll('input[name="wordLength"]');
+  const saved = localStorage.getItem('wordLength') || 'mixed';
+  radios.forEach((radio) => {
+    if (radio.value === saved) {
+      radio.checked = true;
+    }
+    radio.addEventListener('change', () => {
+      localStorage.setItem('wordLength', radio.value);
+    });
+  });
+
+  const backBtn = document.getElementById('back');
+  backBtn.addEventListener('click', () => {
+    window.location.href = '../';
+  });
+});


### PR DESCRIPTION
## Summary
- add word length selection to options menu and persist choice
- filter game word list based on selected length
- prefetch settings script for offline support

## Testing
- `node -e "const words=require('./game/data/words-fr.json');console.log('total',words.length);console.log('short',words.filter(w=>w.word.length<=5).length);console.log('long',words.filter(w=>w.word.length>=6).length);"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a30ea4c833281f941178d30214f