### PR TITLE
style: refresh settings menu design

### DIFF
--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -16,22 +16,52 @@ h1 {
 }
 
 .option-group h2 {
-  color: #ff9966;
-  margin-bottom: 1rem;
-  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #333;
 }
 
-.option-group label {
-  display: block;
-  margin: 0.5rem 0;
+.option-group select {
+  appearance: none;
+  border: none;
+  outline: none;
+  font: inherit;
+  width: 100%;
+  padding: 0.75rem 2.5rem 0.75rem 1rem;
+  border-radius: 8px;
+  background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23333' viewBox='0 0 320 512'%3E%3Cpath d='M31.3 192h257.4c28.4 0 42.8 34.5 22.6 54.6L182.6 375.4c-12.5 12.5-32.8 12.5-45.3 0L8.7 246.6C-11.6 226.5 2.8 192 31.3 192z'/%3E%3C/svg%3E") no-repeat right 0.8rem center/1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
-.option-group .desc {
-  font-size: 0.85rem;
-  color: #555;
-  margin-left: 1.5rem;
+.option-group select option {
+  color: #333;
+}
+
+.option-group select:focus {
+  outline: none;
 }
 
 .back-btn {
-  margin-top: 2rem;
+  margin: 2rem auto 0;
+  display: block;
+}
+
+.btn {
+  font-family: "Nunito", sans-serif;
+  font-size: 1.25rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  opacity: 0.9;
+}
+
+.options {
+  background-color: #2196f3;
+  color: #fff;
 }

--- a/settings/index.html
+++ b/settings/index.html
@@ -14,19 +14,12 @@
   <h1 class="titan-one-regular">Paramètres</h1>
 
   <section class="option-group nunito-regular">
-    <h2>🟧 Longueur des mots</h2>
-    <label>
-      <input type="radio" name="wordLength" value="short">
-      Court seulement – <span class="desc">mots de 5 lettres ou moins</span>
-    </label>
-    <label>
-      <input type="radio" name="wordLength" value="mixed">
-      Mélangé (défaut) – <span class="desc">toutes les longueurs</span>
-    </label>
-    <label>
-      <input type="radio" name="wordLength" value="long">
-      Long seulement – <span class="desc">mots de 6 lettres ou plus</span>
-    </label>
+    <h2 class="nunito-regular">🟧 Longueur des mots</h2>
+    <select id="wordLength" name="wordLength" class="nunito-regular">
+      <option value="short">Court seulement – mots de 5 lettres ou moins</option>
+      <option value="mixed">Mélangé (défaut) – toutes les longueurs</option>
+      <option value="long">Long seulement – mots de 6 lettres ou plus</option>
+    </select>
   </section>
 
   <button id="back" class="btn options back-btn nunito-regular">Retour</button>

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -1,13 +1,9 @@
 window.addEventListener('DOMContentLoaded', () => {
-  const radios = document.querySelectorAll('input[name="wordLength"]');
+  const select = document.getElementById('wordLength');
   const saved = localStorage.getItem('wordLength') || 'mixed';
-  radios.forEach((radio) => {
-    if (radio.value === saved) {
-      radio.checked = true;
-    }
-    radio.addEventListener('change', () => {
-      localStorage.setItem('wordLength', radio.value);
-    });
+  select.value = saved;
+  select.addEventListener('change', () => {
+    localStorage.setItem('wordLength', select.value);
   });
 
   const backBtn = document.getElementById('back');


### PR DESCRIPTION
## Summary
- replace radio button list with app-like select drop-down
- restyle settings sub-headers and back button for consistent menu look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b20f873e48332853bef802b361502