### PR TITLE
Fix emoji wheel spin and sequencing

### DIFF
--- a/celebration/css/celebration.css
+++ b/celebration/css/celebration.css
@@ -78,18 +78,18 @@ body {
   transform: rotate(var(--angle)) translate(var(--radius)) rotate(calc(-1 * var(--angle)));
 }
 
-.emoji-wrapper.spin {
-  animation: wrapperSpin 0.6s ease-in-out;
-}
-
-@keyframes wrapperSpin {
-  from { transform: rotate(var(--angle)) translate(var(--radius)) rotate(calc(-1 * var(--angle))) rotate(0deg); }
-  to { transform: rotate(var(--angle)) translate(var(--radius)) rotate(calc(-1 * var(--angle))) rotate(360deg); }
-}
-
 .emoji {
   display: block;
   transform-origin: center;
+}
+
+.emoji.spin {
+  animation: emojiSpin 0.6s ease-in-out;
+}
+
+@keyframes emojiSpin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 @keyframes pulse {

--- a/celebration/js/celebration.js
+++ b/celebration/js/celebration.js
@@ -28,11 +28,11 @@ window.addEventListener('DOMContentLoaded', () => {
 
     wrapper.appendChild(span);
     container.appendChild(wrapper);
-    wrappers.push(wrapper);
+    wrappers.push(span);
   });
 
   const spinDuration = 600;
-  const overlap = 0.66; // start next spin when current is 66% done
+  const overlap = 0.5; // start next spin when current is 50% done
   function wave(i = 0) {
     if (!wrappers.length) return;
     const el = wrappers[i];


### PR DESCRIPTION
## Summary
- keep celebration emoji wheel centered by spinning each emoji in place
- start next emoji spin at 50% overlap for smoother wave

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b243ad2408332b7af33358b130d4b