### PR TITLE
Improve word length options preview and test mode

### DIFF
--- a/mode/index.html
+++ b/mode/index.html
@@ -17,8 +17,8 @@
     <div class="modes">
       <div class="mode-option">
         <div class="preview" aria-hidden="true"></div>
-        <button class="btn play mode-btn" data-count="1" data-emoji="⚡" style="--clr:#ffca28">
-          Test<br><small>1 mot</small>
+        <button class="btn play mode-btn" data-count="3" data-emoji="⚡" style="--clr:#ffca28">
+          Test<br><small>3 mots</small>
         </button>
       </div>
       <div class="mode-option">

--- a/settings/index.html
+++ b/settings/index.html
@@ -14,11 +14,11 @@
   <h1 class="titan-one-regular">Paramètres</h1>
 
   <section class="option-group nunito-regular">
-    <h2 class="nunito-regular">🟧 Longueur des mots</h2>
+    <h2 class="nunito-regular">Longueur des mots</h2>
     <select id="wordLength" name="wordLength" class="nunito-regular">
-      <option value="short">Court seulement – mots de 5 lettres ou moins</option>
-      <option value="mixed">Mélangé (défaut) – toutes les longueurs</option>
-      <option value="long">Long seulement – mots de 6 lettres ou plus</option>
+      <option value="short" data-short="Court seulement" data-long="Court seulement – mots de 5 lettres ou moins">Court seulement – mots de 5 lettres ou moins</option>
+      <option value="mixed" data-short="Mélangé (défaut)" data-long="Mélangé (défaut) – toutes les longueurs">Mélangé (défaut) – toutes les longueurs</option>
+      <option value="long" data-short="Long seulement" data-long="Long seulement – mots de 6 lettres ou plus">Long seulement – mots de 6 lettres ou plus</option>
     </select>
   </section>
 

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -2,9 +2,29 @@ window.addEventListener('DOMContentLoaded', () => {
   const select = document.getElementById('wordLength');
   const saved = localStorage.getItem('wordLength') || 'mixed';
   select.value = saved;
+
+  const showLongOptions = () => {
+    Array.from(select.options).forEach((opt) => {
+      opt.textContent = opt.dataset.long;
+    });
+  };
+
+  const setPreview = () => {
+    showLongOptions();
+    const selected = select.selectedOptions[0];
+    if (selected) {
+      selected.textContent = selected.dataset.short;
+    }
+  };
+
+  select.addEventListener('focus', showLongOptions);
   select.addEventListener('change', () => {
     localStorage.setItem('wordLength', select.value);
+    setPreview();
   });
+  select.addEventListener('blur', setPreview);
+
+  setPreview();
 
   const backBtn = document.getElementById('back');
   backBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Clean up settings header and show short word-length labels while keeping detailed descriptions in dropdown
- Allow settings script to toggle between short preview text and full option labels
- Expand Test mode to present three words instead of one

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b6b2864f08332b7c2f9865b389fc7