### PR TITLE
style: shorten word length option labels

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -16,9 +16,9 @@
   <section class="option-group nunito-regular">
     <h2 class="nunito-regular">Longueur des mots</h2>
     <select id="wordLength" name="wordLength" class="nunito-regular">
-      <option value="short" data-short="Court seulement" data-long="Court seulement – mots de 5 lettres ou moins">Court seulement – mots de 5 lettres ou moins</option>
-      <option value="mixed" data-short="Mélangé (défaut)" data-long="Mélangé (défaut) – toutes les longueurs">Mélangé (défaut) – toutes les longueurs</option>
-      <option value="long" data-short="Long seulement" data-long="Long seulement – mots de 6 lettres ou plus">Long seulement – mots de 6 lettres ou plus</option>
+      <option value="short" data-short="Short words only" data-long="Short words only – words of 5 letters or fewer">Short words only – words of 5 letters or fewer</option>
+      <option value="mixed" data-short="All words" data-long="All words – any length">All words – any length</option>
+      <option value="long" data-short="Long words only" data-long="Long words only – words of 6 letters or more">Long words only – words of 6 letters or more</option>
     </select>
   </section>
 


### PR DESCRIPTION
## Summary
- use concise wording for word length options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b75f0b6348332a9b457c53fd6a47f