### PR TITLE
Translate word length options to French

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -16,9 +16,9 @@
   <section class="option-group nunito-regular">
     <h2 class="nunito-regular">Longueur des mots</h2>
     <select id="wordLength" name="wordLength" class="nunito-regular">
-      <option value="short" data-short="Short words only" data-long="Short words only – words of 5 letters or fewer">Short words only – words of 5 letters or fewer</option>
-      <option value="mixed" data-short="All words" data-long="All words – any length">All words – any length</option>
-      <option value="long" data-short="Long words only" data-long="Long words only – words of 6 letters or more">Long words only – words of 6 letters or more</option>
+      <option value="short" data-short="Mots courts" data-long="Mots courts uniquement">Mots courts</option>
+      <option value="mixed" data-short="Tous les mots" data-long="Tous les mots">Tous les mots</option>
+      <option value="long" data-short="Mots longs" data-long="Mots longs uniquement">Mots longs</option>
     </select>
   </section>
 


### PR DESCRIPTION
## Summary
- localize word length choices into French and drop numeric details for simpler wording

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b7898e370833282a145fa97d500dc