### PR TITLE
Fix oversized next button

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -5,7 +5,6 @@
   --tile-font: clamp(2rem, 5vw, 3rem);
   --picture-size: clamp(6.5rem, 20vw, 12rem);
   --btn-font: clamp(1.2rem, 3vw, 1.6rem);
-  --next-font: clamp(2rem, 5vw, 3rem);
 }
 
 body {
@@ -93,13 +92,6 @@ body {
   top: 60%;
   transform: translateX(-50%);
   z-index: 2;
-  font-size: var(--next-font);
-  padding: 1.25rem 2.5rem;
-}
-
-/* bigger arrow icon on next button */
-#next span {
-  font-size: 2em;
 }
 
 /* button styles moved to base.css */


### PR DESCRIPTION
## Summary
- standardize "Mot suivant" button height to align with other buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b85cf1df483328ea48b594133c91a