### PR TITLE
Add letter audio playback on correct tile placement

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -40,3 +40,25 @@ export function playError() {
     console.log('Error!');
   }
 }
+
+// Cache letter audio elements so each file is loaded once and reused.
+// Using HTMLAudioElement playback allows us to debounce per letter by
+// simply ignoring play requests while the audio is already playing.
+const letterCache = {};
+
+export function playLetter(letter) {
+  const upper = letter.toUpperCase();
+  try {
+    let audio = letterCache[upper];
+    if (!audio) {
+      const url = new URL(`../../assets/audio/alphabet/FR/${upper}.mp3`, import.meta.url);
+      audio = new Audio(url.href);
+      letterCache[upper] = audio;
+    }
+    if (!audio.paused) return; // debounce: don't overlap same letter audio
+    audio.currentTime = 0;
+    audio.play().catch(() => {});
+  } catch (e) {
+    console.log('Letter', upper);
+  }
+}

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -1,4 +1,4 @@
-import { playSuccess, playError } from './audio.mjs';
+import { playSuccess, playError, playLetter } from './audio.mjs';
 
 export function setupDragDrop(slots, tiles, onComplete) {
   const isComplete = () => slots.every((s) => s.classList.contains('filled'));
@@ -93,6 +93,8 @@ export function setupDragDrop(slots, tiles, onComplete) {
         tile.used = true;
         tile.style.visibility = 'hidden';
         playSuccess();
+        // After the success chime, announce the locked-in letter.
+        setTimeout(() => playLetter(letter), 500);
         dropSlot.addEventListener('animationend', () => dropSlot.classList.remove('placed'), { once: true });
         if (isComplete()) {
           onComplete();


### PR DESCRIPTION
## Summary
- play letter-specific audio after placing a tile in the correct slot
- debounce letter playback so spamming doesn't overlap

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bf1391ce483328549f20835cf0e0b