### PR TITLE
Fix letter audio playback issues

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -49,8 +49,8 @@ export async function playError() {
 }
 
 // Cache letter audio elements so each file is loaded once and reused.
-// Using HTMLAudioElement playback allows us to debounce per letter by
-// simply ignoring play requests while the audio is already playing.
+// Each playback explicitly resets the element so the requested letter
+// always plays, even if the same letter is triggered rapidly.
 const letterCache = {};
 
 export async function playLetter(letter) {
@@ -63,7 +63,8 @@ export async function playLetter(letter) {
       audio = new Audio(url.href);
       letterCache[upper] = audio;
     }
-    if (!audio.paused) return; // debounce: don't overlap same letter audio
+    // Always restart playback so the letter audio is heard every time.
+    audio.pause();
     audio.currentTime = 0;
     await audio.play().catch(() => {});
   } catch (e) {

--- a/game/js/drag-drop.mjs
+++ b/game/js/drag-drop.mjs
@@ -1,4 +1,4 @@
-import { playSuccess, playError, playLetter } from './audio.mjs';
+import { playLetter } from './audio.mjs';
 
 export function setupDragDrop(slots, tiles, onComplete) {
   const isComplete = () => slots.every((s) => s.classList.contains('filled'));
@@ -92,9 +92,8 @@ export function setupDragDrop(slots, tiles, onComplete) {
         dropSlot.classList.remove('preview');
         tile.used = true;
         tile.style.visibility = 'hidden';
-        playSuccess();
-        // After the success chime, announce the locked-in letter.
-        setTimeout(() => playLetter(letter), 500);
+        // Announce the locked-in letter immediately upon correct placement.
+        playLetter(letter);
         dropSlot.addEventListener('animationend', () => dropSlot.classList.remove('placed'), { once: true });
         if (isComplete()) {
           onComplete();
@@ -102,7 +101,6 @@ export function setupDragDrop(slots, tiles, onComplete) {
       } else {
         wrongDrop = true;
         dropSlot.classList.add('wrong', 'flash-letter');
-        playError();
         dropSlot.addEventListener('animationend', () => {
           dropSlot.classList.remove('wrong');
           dropSlot.classList.remove('flash-letter');


### PR DESCRIPTION
## Summary
- Remove success/error tones during letter placement and play the letter audio immediately
- Reset cached audio elements before playback to ensure each letter is heard

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cc5a716748332a25afbe330466820