### PR TITLE
Bump service worker cache version to refresh audio assets

### DIFF
--- a/sw-register.js
+++ b/sw-register.js
@@ -1,3 +1,4 @@
+const SW_VERSION = 'v2';
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker.register(`/sw.js?v=${SW_VERSION}`);
 }

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'mpm-cache-v1';
+const CACHE_NAME = 'mpm-cache-v2';
 const ASSETS = [
   '/',
   'index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache name to `v2`
- register service worker with versioned URL to ensure updates

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cc954c56c8332807788f94fd96462