### PR TITLE
Reshow progress bar when cache version changes

### DIFF
--- a/js/landing.js
+++ b/js/landing.js
@@ -164,9 +164,10 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   requestAnimationFrame(step);
 
-  if (!localStorage.getItem('prefetched')) {
+  const PREFETCH_VERSION = 'mpm-cache-v2';
+  if (localStorage.getItem('prefetched') !== PREFETCH_VERSION) {
     await prefetchResources();
-    localStorage.setItem('prefetched', '1');
+    localStorage.setItem('prefetched', PREFETCH_VERSION);
   } else {
     overlay.classList.add('hidden');
   }


### PR DESCRIPTION
## Summary
- show loading progress bar again when the service worker cache version changes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd6d11f588332bda6f15ddad67665