### PR TITLE
fix: reliable letter audio playback

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -1,21 +1,40 @@
-// Cache letter audio elements so each file is loaded once and reused.
-// Each playback explicitly resets the element so the requested letter
-// always plays, even if the same letter is triggered rapidly.
+// Use the Web Audio API so letter pronunciations play reliably across
+// browsers. Each letter is fetched and decoded once, then an
+// AudioBufferSourceNode is created for every playback. This avoids
+// "first play" issues seen on Safari and Chromium where HTMLAudio
+// elements sometimes fail to start or cut off.
+const ctx = new (window.AudioContext || window.webkitAudioContext)();
 const letterCache = {};
+
+async function loadBuffer(letter) {
+  const url = new URL(`../../assets/audio/alphabet/FR/${letter}.mp3`, import.meta.url);
+  const res = await fetch(url);
+  const arrayBuffer = await res.arrayBuffer();
+  // Safari still uses the callback form for decodeAudioData, while newer
+  // browsers return a Promise. Support both signatures.
+  if (ctx.decodeAudioData.length === 1) {
+    return ctx.decodeAudioData(arrayBuffer);
+  }
+  return new Promise((resolve, reject) => {
+    ctx.decodeAudioData(arrayBuffer, resolve, reject);
+  });
+}
 
 export async function playLetter(letter) {
   const upper = letter.toUpperCase();
   try {
-    let audio = letterCache[upper];
-    if (!audio) {
-      const url = new URL(`../../assets/audio/alphabet/FR/${upper}.mp3`, import.meta.url);
-      audio = new Audio(url.href);
-      letterCache[upper] = audio;
+    let buffer = letterCache[upper];
+    if (!buffer) {
+      buffer = await loadBuffer(upper);
+      letterCache[upper] = buffer;
     }
-    // Always restart playback so the letter audio is heard every time.
-    audio.pause();
-    audio.currentTime = 0;
-    await audio.play().catch(() => {});
+    if (ctx.state === 'suspended') {
+      await ctx.resume();
+    }
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(ctx.destination);
+    source.start(0);
   } catch (e) {
     console.log('Letter', upper);
   }


### PR DESCRIPTION
## Summary
- use Web Audio API for letter pronunciations
- ensure audio buffers are loaded once and played reliably

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ce8a145cc833282d874eb7c315398