### PR TITLE
Use HTMLAudioElement for letter playback

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -1,40 +1,19 @@
-// Use the Web Audio API so letter pronunciations play reliably across
-// browsers. Each letter is fetched and decoded once, then an
-// AudioBufferSourceNode is created for every playback. This avoids
-// "first play" issues seen on Safari and Chromium where HTMLAudio
-// elements sometimes fail to start or cut off.
-const ctx = new (window.AudioContext || window.webkitAudioContext)();
+// Play letter pronunciations using simple HTMLAudioElements. Each
+// letter's audio element is cached and rewound to the start on every
+// playback.
 const letterCache = {};
-
-async function loadBuffer(letter) {
-  const url = new URL(`../../assets/audio/alphabet/FR/${letter}.mp3`, import.meta.url);
-  const res = await fetch(url);
-  const arrayBuffer = await res.arrayBuffer();
-  // Safari still uses the callback form for decodeAudioData, while newer
-  // browsers return a Promise. Support both signatures.
-  if (ctx.decodeAudioData.length === 1) {
-    return ctx.decodeAudioData(arrayBuffer);
-  }
-  return new Promise((resolve, reject) => {
-    ctx.decodeAudioData(arrayBuffer, resolve, reject);
-  });
-}
 
 export async function playLetter(letter) {
   const upper = letter.toUpperCase();
   try {
-    let buffer = letterCache[upper];
-    if (!buffer) {
-      buffer = await loadBuffer(upper);
-      letterCache[upper] = buffer;
+    let audio = letterCache[upper];
+    if (!audio) {
+      const url = new URL(`../../assets/audio/alphabet/FR/${upper}.mp3`, import.meta.url);
+      audio = new Audio(url);
+      letterCache[upper] = audio;
     }
-    if (ctx.state === 'suspended') {
-      await ctx.resume();
-    }
-    const source = ctx.createBufferSource();
-    source.buffer = buffer;
-    source.connect(ctx.destination);
-    source.start(0);
+    audio.currentTime = 0;
+    await audio.play();
   } catch (e) {
     console.log('Letter', upper);
   }


### PR DESCRIPTION
## Summary
- replace Web Audio API usage with cached HTMLAudioElements
- simplify letter sound playback without fetch/decode step

## Testing
- `node --check game/js/audio.mjs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cfb3054588332b1b533014e81b06c