### PR TITLE
Add start overlay to unlock audio context

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -328,3 +328,17 @@ body.word-fade-in {
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+.start-overlay {
+  position: fixed;
+  inset: 0;
+  background: #f7f7f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5;
+}
+
+.start-overlay.hidden {
+  display: none;
+}

--- a/game/index.html
+++ b/game/index.html
@@ -11,6 +11,9 @@
   <link rel="stylesheet" href="css/game.css">
 </head>
 <body>
+  <div id="start-overlay" class="start-overlay">
+    <button id="start-btn" class="btn play">Commencer</button>
+  </div>
   <div id="picture" aria-label="Illustration"></div>
   <div id="word" class="word"></div>
   <div id="tiles" class="tiles"></div>

--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -15,7 +15,7 @@ function audioCtx() {
 );
 
 /* ---- 2. helper that guarantees the context is running ---- */
-async function ensureRunning() {
+export async function ensureRunning() {
   const c = audioCtx();
   if (c.state !== 'running') await c.resume(); // await is vital
 }

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -1,6 +1,7 @@
 import { setupDragDrop } from './drag-drop.mjs';
 import { allSlotsFilled } from './word-check.mjs';
 import { startConfetti as createConfettiEffect } from '../../js/confetti.js';
+import { ensureRunning } from './audio.mjs';
 
 let stopConfettiEffect;
 let bounceCount = 0;
@@ -401,9 +402,16 @@ window.addEventListener('DOMContentLoaded', () => {
   sessionLimit = parseLimit(sessionStorage.getItem('wordLimit'));
   loadHistory();
   renderHistory();
-  startGame();
   repositionTiles();
   document.fonts.ready.then(repositionTiles);
+
+  const overlay = document.getElementById('start-overlay');
+  const startBtn = document.getElementById('start-btn');
+  startBtn.addEventListener('click', async () => {
+    overlay.classList.add('hidden');
+    await ensureRunning();
+    startGame();
+  });
 
   const settingsBtn = document.getElementById('settings-btn');
   const continueBtn = document.getElementById('continue-btn');


### PR DESCRIPTION
## Summary
- add start overlay with button to begin gameplay
- resume Web Audio context on start so first letter plays immediately
- export and import `ensureRunning` to manually start audio

## Testing
- `npm test` (fails: no package.json)
- `node --check game/js/main.mjs`
- `node --check game/js/audio.mjs`


------
https://chatgpt.com/codex/tasks/task_e_688d38ac90fc8332aebf252031ed4728