### PR TITLE
Enhance first word selection transition

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -332,7 +332,7 @@ body.word-fade-in {
 .start-overlay {
   position: fixed;
   inset: 0;
-  background: #f7f7f5;
+  background: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -353,15 +353,11 @@ body.word-fade-in {
 .word-choices {
   margin-top: 2rem;
   display: grid;
-  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  grid-template-columns: repeat(2, minmax(160px, 1fr));
   gap: 1rem;
 }
 
 .word-option {
-  background: #fdfdfd;
-  border-radius: 12px;
-  padding: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -370,10 +366,14 @@ body.word-fade-in {
 .word-btn {
   width: 100%;
   height: 100%;
-  font-size: 3rem;
-  background-color: var(--clr, #4caf50);
-  color: #fff;
-  transition: transform 0.2s, box-shadow 0.2s;
+  padding: 0;
+  font-size: 5rem;
+  background-color: #fff;
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.3s;
 }
 
 .word-btn:hover {
@@ -382,4 +382,16 @@ body.word-fade-in {
 
 .word-btn.selected {
   animation: pop 0.3s ease;
+}
+
+/* Fade-out transition when a word is selected */
+.start-overlay.selection-made h1,
+.start-overlay.selection-made .word-option:not(.selected) {
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.start-overlay.selection-made .word-option.selected .word-btn {
+  background: transparent;
+  box-shadow: none;
 }

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -393,13 +393,36 @@ function closeSettings() {
 
 async function handleFirstSelection(wordObj, btn) {
   btn.classList.add('selected');
+  btn.parentElement.classList.add('selected');
   const overlay = document.getElementById('start-overlay');
   const startRect = btn.getBoundingClientRect();
+
   await ensureRunning();
   showWord(wordObj);
   previousWord = wordObj;
+
+  // Hide game elements until transition completes
+  const revealEls = [
+    document.getElementById('picture'),
+    document.getElementById('word'),
+    document.getElementById('tiles'),
+    document.getElementById('settings-btn'),
+    document.getElementById('message'),
+    document.getElementById('history'),
+    document.getElementById('next'),
+  ];
+  revealEls.forEach((el) => {
+    if (el) el.style.opacity = 0;
+  });
+
+  // Fade out other choices and title
+  overlay.classList.add('selection-made');
+  await new Promise((res) => setTimeout(res, 300));
+
   const picture = document.getElementById('picture');
   const endRect = picture.getBoundingClientRect();
+
+  // Create flying emoji at original position
   const fly = document.createElement('span');
   fly.textContent = wordObj.emoji;
   fly.style.position = 'fixed';
@@ -409,6 +432,8 @@ async function handleFirstSelection(wordObj, btn) {
   fly.style.fontSize = window.getComputedStyle(picture).fontSize;
   fly.style.zIndex = '10';
   document.body.appendChild(fly);
+  btn.style.visibility = 'hidden';
+
   await fly
     .animate(
       [
@@ -426,6 +451,14 @@ async function handleFirstSelection(wordObj, btn) {
     .finished;
   document.body.removeChild(fly);
   overlay.classList.add('hidden');
+
+  // Reveal game elements
+  revealEls.forEach((el) => {
+    if (el) {
+      el.style.transition = 'opacity 0.3s';
+      el.style.opacity = 1;
+    }
+  });
 }
 
 function renderFirstWordOptions() {
@@ -439,7 +472,7 @@ function renderFirstWordOptions() {
     const option = document.createElement('div');
     option.className = 'word-option';
     const btn = document.createElement('button');
-    btn.className = 'btn play word-btn';
+    btn.className = 'word-btn';
     btn.textContent = wordObj.emoji;
     btn.addEventListener('click', () => handleFirstSelection(wordObj, btn));
     option.appendChild(btn);


### PR DESCRIPTION
## Summary
- enlarge emoji selection buttons and give them white backgrounds
- add fade-out and fly-to-top animation when starting the first word
- fade in game elements after emoji transition

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688df25a2fd88332bdd2939b0193b057