### PR TITLE
Fix tile drag stuck by animation

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -231,14 +231,19 @@ function animateTilesIn(tiles) {
   const order = [...tiles];
   shuffle(order);
   order.forEach((tile, idx) => {
-    tile.animate(
+    const anim = tile.animate(
       [
         { transform: 'scale(0)', opacity: 0 },
         { transform: 'scale(1.2)', opacity: 1 },
         { transform: 'scale(1)', opacity: 1 }
       ],
-      { duration: 300, easing: 'ease-out', delay: idx * 150, fill: 'forwards' }
+      { duration: 300, easing: 'ease-out', delay: idx * 150 }
     );
+    anim.addEventListener('finish', () => {
+      tile.style.opacity = 1;
+      tile.style.transform = '';
+      anim.cancel();
+    });
   });
 }
 
@@ -469,7 +474,7 @@ async function handleFirstSelection(wordObj, btn) {
       { duration: 300, easing: 'ease-in-out', fill: 'forwards' }
     )
     .finished;
-  await new Promise((res) => setTimeout(res, 500));
+  await new Promise((res) => setTimeout(res, 400));
   overlay.classList.add('hidden');
 
   // Reveal game elements


### PR DESCRIPTION
## Summary
- Cancel tile fade-in animations and reset styles so tiles can be dragged once visible
- Shorten delay before gameplay elements fade in after selecting first emoji

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game/js/main.mjs`

------
https://chatgpt.com/codex/tasks/task_e_688e0b83a6b0833291923c17f20e4833