### PR TITLE
Disable tile animation after first word

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -405,7 +405,7 @@ async function startGame() {
     wordList = await loadWords();
   }
   const word = nextWord();
-  showWord(word);
+  showWord(word, wordsPlayed === 0);
 }
 
 function openSettings() {


### PR DESCRIPTION
## Summary
- Skip tile appearance animations for words after the first to keep gameplay responsive

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688e0fa6dd7083328192ba478f7627c0