### PR TITLE
fix: show tiles after first word

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -397,6 +397,15 @@ function showWord(wordObj, animateTiles = true) {
   };
   if (animateTiles) {
     requestAnimationFrame(() => animateTilesIn(tiles));
+  } else if (wordsPlayed > 0) {
+    // When switching to the next word we skip the entrance animation to
+    // avoid delay, but the tiles still need to be visible. Explicitly reset
+    // the styles that `createTiles` uses to hide them so they appear
+    // immediately.
+    tiles.forEach((tile) => {
+      tile.style.opacity = 1;
+      tile.style.transform = '';
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure letter tiles are revealed for words after the first one

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e27d419d48332ab38ff2be5e4e5b9