### PR TITLE
Play word audio after discovery

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -1,7 +1,7 @@
 import { setupDragDrop } from './drag-drop.mjs';
 import { allSlotsFilled } from './word-check.mjs';
 import { startConfetti as createConfettiEffect } from '../../js/confetti.js';
-import { ensureRunning } from './audio.mjs';
+import { ensureRunning, playWord } from './audio.mjs';
 
 let stopConfettiEffect;
 let bounceCount = 0;
@@ -348,16 +348,17 @@ async function animateWordReveal(slots) {
   );
   await Promise.all(animations);
 
-  await wordEl
-    .animate(
-      [
-        { transform: 'scale(1)' },
-        { transform: 'scale(1.3)' },
-        { transform: 'scale(1)' },
-      ],
-      { duration, easing: 'ease' }
-    )
-    .finished;
+  const word = slots.map((s) => s.textContent).join('');
+  const wordAnim = wordEl.animate(
+    [
+      { transform: 'scale(1)' },
+      { transform: 'scale(1.3)' },
+      { transform: 'scale(1)' },
+    ],
+    { duration, easing: 'ease' }
+  );
+  playWord(word);
+  await wordAnim.finished;
 }
 
 function showWord(wordObj, animateTiles = true) {


### PR DESCRIPTION
## Summary
- add support for word audio clips and cache decoding
- trigger word audio when a completed word pulses during celebration

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f40304ec4833292a159219e452ca8