### PR TITLE
Add success audio after word completion

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -65,5 +65,25 @@ export async function playWord(word) {
   src.start();
 }
 
-// This module intentionally only exposes the letter and word audio. All other
-// feedback sounds have been removed for a quieter gameplay experience.
+export async function playSuccess() {
+  await ensureRunning();
+  const key = 'SFX:SUCCESS';
+  let buf = cache[key];
+  if (!buf) {
+    const url = new URL(
+      '../../assets/audio/SFX/SUCCESS.mp3',
+      import.meta.url
+    );
+    const res = await fetch(url, { mode: 'cors' });
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+    const bytes = await res.arrayBuffer();
+    buf = cache[key] = await audioCtx().decodeAudioData(bytes);
+  }
+  const src = audioCtx().createBufferSource();
+  src.buffer = buf;
+  src.connect(audioCtx().destination);
+  src.start();
+  return new Promise((res) => src.addEventListener('ended', res, { once: true }));
+}
+
+// This module intentionally only exposes the letter, word, and success audio.

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -1,7 +1,7 @@
 import { setupDragDrop } from './drag-drop.mjs';
 import { allSlotsFilled } from './word-check.mjs';
 import { startConfetti as createConfettiEffect } from '../../js/confetti.js';
-import { ensureRunning, playWord } from './audio.mjs';
+import { ensureRunning, playWord, playSuccess } from './audio.mjs';
 
 let stopConfettiEffect;
 let bounceCount = 0;
@@ -348,6 +348,7 @@ async function animateWordReveal(slots) {
   );
   await Promise.all(animations);
 
+  await playSuccess();
   const word = slots.map((s) => s.textContent).join('');
   const wordAnim = wordEl.animate(
     [


### PR DESCRIPTION
## Summary
- play success SFX before the completed word audio
- expose `playSuccess` in audio utilities and use it after the tile pulse animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f5bdae6c0833287b89d18ed186a1c