### PR TITLE
Play success audio with celebration

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -63,6 +63,7 @@ export async function playWord(word) {
   src.buffer = buf;
   src.connect(audioCtx().destination);
   src.start();
+  return new Promise((res) => src.addEventListener('ended', res, { once: true }));
 }
 
 export async function playSuccess() {

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -348,7 +348,6 @@ async function animateWordReveal(slots) {
   );
   await Promise.all(animations);
 
-  await playSuccess();
   const word = slots.map((s) => s.textContent).join('');
   const wordAnim = wordEl.animate(
     [
@@ -358,8 +357,7 @@ async function animateWordReveal(slots) {
     ],
     { duration, easing: 'ease' }
   );
-  playWord(word);
-  await wordAnim.finished;
+  await Promise.all([playWord(word), wordAnim.finished]);
 }
 
 function showWord(wordObj, animateTiles = true) {
@@ -376,8 +374,9 @@ function showWord(wordObj, animateTiles = true) {
   setupDragDrop(slots, tiles, () => {
       if (allSlotsFilled(slots)) {
         animateWordReveal(slots).then(() => {
-          addToHistory(wordObj.emoji);
+          playSuccess();
           celebrate();
+          addToHistory(wordObj.emoji);
           wordsPlayed++;
           if (sessionLimit !== Infinity && wordsPlayed >= sessionLimit) {
             endGame();


### PR DESCRIPTION
## Summary
- Start celebration only after word audio completes
- Trigger success audio together with celebration sequence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f62426e1c83329390033a487ed6fb