### PR TITLE
Add bubble SFX for tile spawn animation

### DIFF
--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -87,4 +87,31 @@ export async function playSuccess() {
   return new Promise((res) => src.addEventListener('ended', res, { once: true }));
 }
 
-// This module intentionally only exposes the letter, word, and success audio.
+const bubbleHistory = [];
+
+export async function playBubble() {
+  await ensureRunning();
+  const indices = [0, 1, 2, 3, 4];
+  const available = indices.filter((i) => !bubbleHistory.includes(i));
+  const idx = available[Math.floor(Math.random() * available.length)];
+  const key = `SFX:BUBBLE_${idx}`;
+  let buf = cache[key];
+  if (!buf) {
+    const url = new URL(
+      `../../assets/audio/SFX/bubbles/bubble_0${idx + 1}.mp3`,
+      import.meta.url
+    );
+    const res = await fetch(url, { mode: 'cors' });
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+    const bytes = await res.arrayBuffer();
+    buf = cache[key] = await audioCtx().decodeAudioData(bytes);
+  }
+  const src = audioCtx().createBufferSource();
+  src.buffer = buf;
+  src.connect(audioCtx().destination);
+  src.start();
+  bubbleHistory.push(idx);
+  if (bubbleHistory.length > 2) bubbleHistory.shift();
+}
+
+// This module intentionally only exposes the letter, word, bubble, and success audio.

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -1,7 +1,7 @@
 import { setupDragDrop } from './drag-drop.mjs';
 import { allSlotsFilled } from './word-check.mjs';
 import { startConfetti as createConfettiEffect } from '../../js/confetti.js';
-import { ensureRunning, playWord, playSuccess } from './audio.mjs';
+import { ensureRunning, playWord, playSuccess, playBubble } from './audio.mjs';
 
 let stopConfettiEffect;
 let bounceCount = 0;
@@ -231,14 +231,16 @@ function animateTilesIn(tiles) {
   const order = [...tiles];
   shuffle(order);
   order.forEach((tile, idx) => {
+    const delay = idx * 150;
     const anim = tile.animate(
       [
         { transform: 'scale(0)', opacity: 0 },
         { transform: 'scale(1.2)', opacity: 1 },
         { transform: 'scale(1)', opacity: 1 }
       ],
-      { duration: 300, easing: 'ease-out', delay: idx * 150 }
+      { duration: 300, easing: 'ease-out', delay }
     );
+    setTimeout(() => playBubble(), delay);
     anim.addEventListener('finish', () => {
       tile.style.opacity = 1;
       tile.style.transform = '';


### PR DESCRIPTION
## Summary
- play random bubble sounds when letters spawn
- ensure bubble sounds rotate to avoid immediate repeats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f64d42880833294515362f4b1c2d5