### PR TITLE
Play bravo sound at final celebration

### DIFF
--- a/celebration/js/celebration.js
+++ b/celebration/js/celebration.js
@@ -1,5 +1,6 @@
 // Use the shared confetti script from the project root.
 import { startConfetti } from '../../js/confetti.js';
+import { playBravo } from '../../game/js/audio.mjs';
 
 window.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('emoji-container');
@@ -8,6 +9,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const emojis = stored ? JSON.parse(stored) : [];
 
   const stopConfetti = startConfetti();
+  playBravo();
 
   const wrappers = [];
   const radius = 35; // circle radius in vmin

--- a/game/js/audio.mjs
+++ b/game/js/audio.mjs
@@ -87,6 +87,27 @@ export async function playSuccess() {
   return new Promise((res) => src.addEventListener('ended', res, { once: true }));
 }
 
+export async function playBravo() {
+  await ensureRunning();
+  const key = 'SFX:BRAVO';
+  let buf = cache[key];
+  if (!buf) {
+    const url = new URL(
+      '../../assets/audio/SFX/BRAVO.mp3',
+      import.meta.url
+    );
+    const res = await fetch(url, { mode: 'cors' });
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+    const bytes = await res.arrayBuffer();
+    buf = cache[key] = await audioCtx().decodeAudioData(bytes);
+  }
+  const src = audioCtx().createBufferSource();
+  src.buffer = buf;
+  src.connect(audioCtx().destination);
+  src.start();
+  return new Promise((res) => src.addEventListener('ended', res, { once: true }));
+}
+
 const bubbleHistory = [];
 
 export async function playBubble() {
@@ -114,4 +135,4 @@ export async function playBubble() {
   if (bubbleHistory.length > 2) bubbleHistory.shift();
 }
 
-// This module intentionally only exposes the letter, word, bubble, and success audio.
+// This module intentionally only exposes the letter, word, bubble, success, and bravo audio.


### PR DESCRIPTION
## Summary
- add `playBravo` helper using Web Audio API
- trigger bravo sound when the celebration page loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f69587b7c8332a4d101ff1c64d611