### PR TITLE
Ensure Bravo audio plays after celebration

### DIFF
--- a/celebration/js/celebration.js
+++ b/celebration/js/celebration.js
@@ -9,7 +9,21 @@ window.addEventListener('DOMContentLoaded', () => {
   const emojis = stored ? JSON.parse(stored) : [];
 
   const stopConfetti = startConfetti();
-  playBravo();
+
+  // Attempt to play the celebration audio immediately; if the browser
+  // blocks autoplay (e.g. due to missing user interaction), retry after
+  // the first pointer/touch/click event.
+  playBravo().catch(() => {
+    const retry = () => {
+      playBravo();
+      ['pointerdown', 'touchstart', 'click'].forEach((t) =>
+        window.removeEventListener(t, retry)
+      );
+    };
+    ['pointerdown', 'touchstart', 'click'].forEach((t) =>
+      window.addEventListener(t, retry, { once: true })
+    );
+  });
 
   const wrappers = [];
   const radius = 35; // circle radius in vmin


### PR DESCRIPTION
## Summary
- Ensure the BRAVO.mp3 sound plays even when autoplay is blocked by retrying on the first user interaction.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fa92bb0c88332883521be1602d723