### PR TITLE
Wrap game elements in layout container

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -17,6 +17,11 @@ body {
   background: #f7f7f5;
   user-select: none;
 }
+.game-layout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 #picture {
   /* enlarge the emoji display */
   font-size: var(--picture-size);
@@ -283,10 +288,12 @@ body {
 
 @media (orientation: landscape) {
   body {
+    padding-top: 1rem;
+  }
+  .game-layout {
     flex-direction: row;
     align-items: flex-start;
     justify-content: space-evenly;
-    padding-top: 1rem;
   }
   #picture {
     margin-right: 2rem;

--- a/game/index.html
+++ b/game/index.html
@@ -18,9 +18,11 @@
       <div id="word-choices" class="word-choices"></div>
     </div>
   </div>
-  <div id="picture" aria-label="Illustration"></div>
-  <div id="word" class="word"></div>
-  <div id="tiles" class="tiles"></div>
+  <div class="game-layout">
+    <div id="picture" aria-label="Illustration"></div>
+    <div id="word" class="word"></div>
+    <div id="tiles" class="tiles"></div>
+  </div>
   <div id="confetti" class="confetti-container"></div>
   <div id="message" class="message"></div>
   <div id="history" class="history"></div>


### PR DESCRIPTION
## Summary
- group picture, word, and tiles elements inside a new `.game-layout` wrapper
- adjust responsive styles to apply landscape flex-row layout on `.game-layout`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc820303c8332ba4677ba4fa5f4ce