### PR TITLE
refactor: responsive tile layout

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -1,10 +1,11 @@
 /* Game screen styling */
 :root {
-  --tile-width: clamp(40px, 10vw, 80px);
-  --tile-height: clamp(50px, 12vw, 100px);
-  --tile-font: clamp(2rem, 5vw, 3rem);
-  --picture-size: clamp(6.5rem, 20vw, 12rem);
-  --btn-font: clamp(1.2rem, 3vw, 1.6rem);
+  --tile-width: clamp(40px, 10vmin, 80px);
+  --tile-height: clamp(50px, 12vmin, 100px);
+  --tile-font: clamp(2rem, 5vmin, 3rem);
+  --picture-size: clamp(6.5rem, 20vmin, 12rem);
+  --btn-font: clamp(1.2rem, 3vmin, 1.6rem);
+  --tiles-height: min(35vh, 80vmin);
 }
 
 body {
@@ -21,6 +22,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  transform-origin: top center;
 }
 #picture {
   /* enlarge the emoji display */
@@ -54,8 +56,7 @@ body {
 }
 .tiles {
   position: relative;
-  height: 35vh;
-  max-height: clamp(300px, 40vh, 500px);
+  height: var(--tiles-height);
   width: 100%;
 }
 .tile {
@@ -302,9 +303,8 @@ body {
   .word {
     margin-bottom: 1rem;
   }
-  .tiles {
-    height: 50vh;
-    width: 100%;
+  :root {
+    --tiles-height: min(50vh, 80vmin);
   }
 }
 

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -15,16 +15,23 @@ function parseLimit(value) {
 let sessionLimit = parseLimit(sessionStorage.getItem('wordLimit'));
 let wordsPlayed = 0;
 
+function updateScale() {
+  const layout = document.querySelector('.game-layout');
+  if (!layout) return;
+  const width = layout.offsetWidth;
+  const height = layout.offsetHeight;
+  const scale = Math.min(window.innerWidth / width, window.innerHeight / height, 1);
+  layout.style.transform = `scale(${scale})`;
+}
+
 function repositionTiles() {
   const container = document.getElementById('tiles');
   if (!container) return;
-  const { width, height } = container.getBoundingClientRect();
+  const width = container.offsetWidth;
+  const height = container.offsetHeight;
   const sampleSlot = document.querySelector('.slot');
-  const slotRect = sampleSlot
-    ? sampleSlot.getBoundingClientRect()
-    : { width: 40, height: 50 };
-  const tileW = slotRect.width;
-  const tileH = slotRect.height;
+  const tileW = sampleSlot ? sampleSlot.offsetWidth : 40;
+  const tileH = sampleSlot ? sampleSlot.offsetHeight : 50;
   const marginX = tileW;
   // use a smaller vertical margin so random placement always has
   // some wiggle room even on short screens
@@ -57,6 +64,11 @@ function repositionTiles() {
     tile.style.left = `${pos.x}px`;
     tile.style.top = `${pos.y}px`;
   });
+}
+
+function handleResize() {
+  updateScale();
+  repositionTiles();
 }
 
 // Emoji history management
@@ -367,7 +379,7 @@ function showWord(wordObj, animateTiles = true) {
   const slots = createSlots(wordObj.word);
   const tiles = createTiles(wordObj.word);
   currentTiles = tiles;
-  document.fonts.ready.then(repositionTiles);
+  document.fonts.ready.then(handleResize);
   const nextBtn = document.getElementById('next');
   nextBtn.style.display = 'none';
   document.getElementById('message').classList.remove('show');
@@ -525,8 +537,8 @@ window.addEventListener('DOMContentLoaded', async () => {
   sessionLimit = parseLimit(sessionStorage.getItem('wordLimit'));
   loadHistory();
   renderHistory();
-  repositionTiles();
-  document.fonts.ready.then(repositionTiles);
+  handleResize();
+  document.fonts.ready.then(handleResize);
 
   wordList = await loadWords();
   const lengthSetting = localStorage.getItem('wordLength') || 'mixed';
@@ -558,5 +570,6 @@ window.addEventListener('DOMContentLoaded', async () => {
     sessionStorage.removeItem('wordHistory');
     window.location.href = '../';
   });
-  window.addEventListener('resize', repositionTiles);
+  window.addEventListener('resize', handleResize);
+  window.addEventListener('orientationchange', handleResize);
 });


### PR DESCRIPTION
## Summary
- use vmin-based CSS variables for tiles and add flexible container height
- scale game layout to fit viewport and reposition tiles on resize or orientation change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc946a4fc8332b337fa665997f2e6