### PR TITLE
refactor: improve landing page layout

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -5,23 +5,10 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   position: relative;
   overflow: hidden;
-  padding-top: 10vh;
   user-select: none;
-}
-
-@media (orientation: portrait) {
-  body {
-    padding-top: 10vh;
-  }
-}
-
-@media (orientation: landscape) {
-  body {
-    padding-top: 5vh;
-  }
 }
 
 .container {
@@ -60,15 +47,15 @@ body {
 }
 
 .title-tile {
-  width: 60px;
-  height: 60px;
+  width: clamp(60px, 6vw, 120px);
+  height: clamp(60px, 6vw, 120px);
   background: #fdfdfd;
   border-radius: 10px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  font-size: clamp(2rem, 4vw, 4rem);
   color: #000;
   user-select: none;
 }
@@ -86,7 +73,12 @@ body {
   flex-direction: column;
   gap: 1rem;
   align-items: center;
-  margin-top: 20vh;
+  margin-top: clamp(2rem, 8vh, 8rem);
+}
+
+.buttons .btn {
+  font-size: clamp(1.25rem, 2vw, 2.5rem);
+  padding: clamp(0.75rem, 1vw, 1.5rem) clamp(1.5rem, 2vw, 3rem);
 }
 
 
@@ -144,5 +136,26 @@ body {
   overflow: hidden;
   line-height: 1;
   user-select: none;
+}
+
+/* Breakpoints for very wide screens */
+@media (min-width: 1600px) {
+  .buttons {
+    flex-direction: row;
+    gap: 2rem;
+  }
+}
+
+@media (min-width: 2200px) {
+  .title-tile {
+    width: clamp(90px, 4vw, 150px);
+    height: clamp(90px, 4vw, 150px);
+    font-size: clamp(3rem, 3vw, 5rem);
+  }
+
+  .buttons .btn {
+    font-size: clamp(2rem, 1.5vw, 3rem);
+    padding: clamp(1rem, 1vw, 2rem) clamp(2rem, 2vw, 4rem);
+  }
 }
 


### PR DESCRIPTION
## Summary
- center landing page content using flexbox instead of orientation-specific padding
- scale title tiles and buttons with `clamp()` for better desktop legibility
- introduce wide-screen breakpoints for horizontal button layout and larger UI elements

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fcd5830e88332b49e453b85d45e9f