### PR TITLE
Adjust game UI element positions and tile spacing

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -93,7 +93,7 @@ body {
 }
 #next {
   position: fixed;
-  bottom: clamp(1rem, 10vh, 4rem);
+  bottom: clamp(8rem, 16vh, 10rem);
   right: 50%;
   transform: translateX(50%);
   z-index: 2;
@@ -122,8 +122,8 @@ body {
   pointer-events: none;
   position: fixed;
   left: 50%;
-  top: 45%;
-  transform: translate(-50%, -50%);
+  top: clamp(0.5rem, 8vh, 3rem);
+  transform: translateX(-50%);
   white-space: nowrap;
   z-index: 2;
 }

--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -55,8 +55,13 @@ function layoutTiles(tiles) {
   const sampleSlot = document.querySelector('.slot');
   const tileW = sampleSlot ? sampleSlot.offsetWidth : 40;
   const tileH = sampleSlot ? sampleSlot.offsetHeight : 50;
-  const cols = Math.min(tiles.length, Math.max(1, Math.floor(width / tileW)));
-  const spacingX = Math.max(0, (width - cols * tileW) / (cols + 1));
+  let cols = Math.min(tiles.length, Math.max(1, Math.floor(width / tileW)));
+  let spacingX = (width - cols * tileW) / (cols + 1);
+  while (cols > 1 && spacingX < tileW * 0.25) {
+    cols--;
+    spacingX = (width - cols * tileW) / (cols + 1);
+  }
+  spacingX = Math.max(spacingX, tileW * 0.25);
   const spacingY = tileH * 0.25;
   const rows = Math.ceil(tiles.length / cols);
   const neededHeight = rows * tileH + (rows + 1) * spacingY;


### PR DESCRIPTION
## Summary
- Move Bravo message above emoji to avoid overlapping letter slots
- Raise Mot suivant button above session progress indicator
- Spread letter tiles across width for short words

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6bf4e6483329a1b31a9bf688a2f