### PR TITLE
Ensure words don't repeat until playlist exhausted

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -172,15 +172,12 @@ function nextWord() {
   if (playlist.length === 0 || playlistIndex >= playlist.length) {
     playlist = [...wordList];
     shuffle(playlist);
-    if (
-      previousWord &&
-      playlist.length > 1 &&
-      playlist[0].word === previousWord.word
-    ) {
-      // ensure we don't repeat the same word twice in a row
-      const swapIdx = playlist.findIndex((w) => w.word !== previousWord.word);
-      if (swapIdx > 0) {
-        [playlist[0], playlist[swapIdx]] = [playlist[swapIdx], playlist[0]];
+    if (previousWord && playlist.length > 1) {
+      // ensure the previously played word only appears after all others
+      const prevIdx = playlist.findIndex((w) => w.word === previousWord.word);
+      if (prevIdx !== -1) {
+        const [prev] = playlist.splice(prevIdx, 1);
+        playlist.push(prev);
       }
     }
     playlistIndex = 0;


### PR DESCRIPTION
## Summary
- Shuffle the word playlist and defer the previous word until after all others, preventing premature repeats.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689196dca7848332bf8162429bcc8a68