### PR TITLE
Expand pickable tile layout width

### DIFF
--- a/game/css/game.css
+++ b/game/css/game.css
@@ -57,7 +57,14 @@ body {
 .tiles {
   position: relative;
   height: var(--tiles-height);
-  width: 100%;
+  width: min(calc(100vw - 2 * var(--tile-width)), calc(var(--tile-width) * 12));
+  margin: 0 auto;
+}
+
+@media (orientation: landscape) {
+  .tiles {
+    margin: 0;
+  }
 }
 .tile {
   width: var(--tile-width);


### PR DESCRIPTION
## Summary
- let pickable letter tiles use the full viewport width minus one tile margin on each side
- cap the tile area to a maximum width of 12 tiles
- avoid flexbox margin conflicts in landscape orientation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68919f3a0c3483328b0eda36c26a5f9d