### PR TITLE
Add pulse animation and audio when tapping word emoji

### DIFF
--- a/game/js/main.mjs
+++ b/game/js/main.mjs
@@ -378,7 +378,19 @@ async function animateWordReveal(slots) {
 }
 
 function showWord(wordObj, animateTiles = true) {
-  document.getElementById('picture').textContent = wordObj.emoji;
+  const pic = document.getElementById('picture');
+  pic.textContent = wordObj.emoji;
+  pic.onpointerdown = () => {
+    pic.animate(
+      [
+        { transform: 'scale(1)' },
+        { transform: 'scale(1.3)' },
+        { transform: 'scale(1)' },
+      ],
+      { duration: 300, easing: 'ease' }
+    );
+    playWord(wordObj.word);
+  };
   const slots = createSlots(wordObj.word);
   const tiles = createTiles(wordObj.word);
   currentTiles = tiles;


### PR DESCRIPTION
## Summary
- Pulse and audio play when tapping the current word emoji

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_6892400d77548332a9df49a5418b6ea7